### PR TITLE
fix: fixing API documentation URL and update swagger options

### DIFF
--- a/src/app/api/v1/docs/page/page.tsx
+++ b/src/app/api/v1/docs/page/page.tsx
@@ -92,7 +92,7 @@ const darkModeStyles = `
 
 export default function ApiDocs() {
   // Get the current URL and replace the path with the API docs endpoint
-  const apiDocsUrl = typeof window !== "undefined" ? `${window.location.origin}/api/v1/docs` : "/api/v1/docs";
+  const apiDocsUrl = "/api/v1/docs";
   const { theme } = useTheme();
   const isDarkMode = () => {
     if (theme === "dark") {

--- a/src/app/api/v1/docs/page/page.tsx
+++ b/src/app/api/v1/docs/page/page.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import "swagger-ui-react/swagger-ui.css";
 
 const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
@@ -91,15 +92,44 @@ const darkModeStyles = `
 `;
 
 export default function ApiDocs() {
-  // Get the current URL and replace the path with the API docs endpoint
-  const apiDocsUrl = "/api/v1/docs";
   const { theme } = useTheme();
+  const [swaggerUrl, setSwaggerUrl] = useState<string>("");
+
+  useEffect(() => {
+    // Determine the correct URL based on the current environment
+    if (typeof window !== "undefined") {
+      const protocol = window.location.protocol;
+      const host = window.location.host;
+      setSwaggerUrl(`${protocol}//${host}/api/v1/docs`);
+    }
+  }, []);
+
   const isDarkMode = () => {
     if (theme === "dark") {
       return <style>{darkModeStyles}</style>;
     }
     return null;
   };
+
+  // Don't render SwaggerUI until we have the correct URL
+  if (!swaggerUrl) {
+    return (
+      <div className="md:max-w-5xl">
+        <div className="border-b">
+          <div className="px-4 py-6">
+            <h1 className="text-3xl font-bold ">Czechibank API Documentation</h1>
+            <p className="mt-2 ">Interactive API documentation for the Czechibank learning application.</p>
+          </div>
+        </div>
+        <div className="p-4">
+          <div className="flex items-center justify-center py-8">
+            <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900 dark:border-white"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="md:max-w-5xl">
       <div className="border-b">
@@ -111,7 +141,7 @@ export default function ApiDocs() {
       {isDarkMode()}
       <div className="p-4">
         <SwaggerUI
-          url={apiDocsUrl}
+          url={swaggerUrl}
           docExpansion="list"
           defaultModelExpandDepth={3}
           persistAuthorization={true}

--- a/src/components/auth/user-button.tsx
+++ b/src/components/auth/user-button.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useSession } from "@/lib/auth-client";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { Button } from "../ui/button";
 import { UserAvatar } from "../user/avatar";
@@ -18,8 +18,12 @@ import { SignOut } from "./sign-out";
 export default function UserButton() {
   const router = useRouter();
   const { data: session, isPending } = useSession();
+  const pathname = usePathname();
 
   useEffect(() => {
+    if (pathname.includes("/api/v1/docs")) {
+      return;
+    }
     if (!isPending && !session?.user) {
       router.push("/signin");
     }

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -33,6 +33,10 @@ All responses follow a consistent format:
         description: "Local Development Server",
       },
       {
+        url: "https://develop.czechibank.ostrava.digital/api/v1",
+        description: "Development Server",
+      },
+      {
         url: "https://czechibank.ostrava.digital/api/v1",
         description: "Production Server",
       },
@@ -262,7 +266,13 @@ All responses follow a consistent format:
       },
     ],
   },
-  apis: ["./src/app/api/v1/**/*.ts", "./src/app/api/v1/**/*.tsx"],
+  apis: [
+    // Use absolute paths from project root
+    process.cwd() + "/src/app/api/v1/**/*.ts",
+    process.cwd() + "/src/app/api/v1/**/*.tsx",
+    // Also include the built files in case we're in production
+    process.cwd() + "/.next/server/app/api/v1/**/*.js",
+  ],
 };
 
 export const swaggerSpec = swaggerJsdoc(options);


### PR DESCRIPTION
- Changed the API documentation URL to a static path for consistency.
- Updated swagger options to use absolute paths from the project root and included built files for production.