### PR TITLE
[CZBANK-59] bug: context menu closing on btn click

### DIFF
--- a/src/components/auth/user-button.tsx
+++ b/src/components/auth/user-button.tsx
@@ -42,13 +42,13 @@ export default function UserButton() {
             <p className="text-xs leading-none text-muted-foreground">{session.user.email}</p>
           </div>
         </DropdownMenuLabel>
-        <DropdownMenuItem>
+        <DropdownMenuItem asChild>
           <Link href="/profile" className="w-full">
             <Button className="w-full">Profile</Button>
           </Link>
         </DropdownMenuItem>
         {session.user.role === "admin" ? (
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <Link href="/administration" className="w-full">
               <Button className="w-full">Administration</Button>
             </Link>


### PR DESCRIPTION
The context menu now closes on button click because the DropdownMenuItem was assigned asChild, allowing the wrapped element (e.g., a Link or Button) to act as the menu item and trigger the menu’s close behavior automatically.