### PR TITLE
[CZBANK-69] bug: back-button cache issue

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,8 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  //timeout: 10000_000,
+  timeout: 30_000,
   testDir: "./tests/e2e",
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ import { defineConfig, devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  //timeout: 10000_000,
+  //timeout: 1_200_000,
   timeout: 30_000,
   testDir: "./tests/e2e",
   /* Run tests in files in parallel */

--- a/src/app/profile/page.client.tsx
+++ b/src/app/profile/page.client.tsx
@@ -88,7 +88,9 @@ export default function ProfileClientPage({
             <div className="flex-1 space-y-4">
               <div>
                 <Label className="text-sm font-medium text-muted-foreground">Name</Label>
-                <p className="text-lg font-semibold">{user.name}</p>
+                <p className="text-lg font-semibold" data-testid="userName">
+                  {user.name}
+                </p>
               </div>
               <div>
                 <Label className="text-sm font-medium text-muted-foreground">Email</Label>

--- a/src/components/auth/sign-out.tsx
+++ b/src/components/auth/sign-out.tsx
@@ -15,11 +15,10 @@ export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
       onClick={async () => {
         await userService.client.signOut({
           onSuccess: () => {
-            router.refresh();
-            router.push("/");
+            window.location.replace("/");
           },
           onError: (error) => {
-            router.refresh();
+            window.location.replace("/");
             console.log(error);
           },
         });

--- a/src/components/auth/sign-out.tsx
+++ b/src/components/auth/sign-out.tsx
@@ -15,9 +15,11 @@ export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
       onClick={async () => {
         await userService.client.signOut({
           onSuccess: () => {
+            router.refresh();
             router.push("/");
           },
           onError: (error) => {
+            router.refresh();
             console.log(error);
           },
         });

--- a/src/components/auth/user-button.tsx
+++ b/src/components/auth/user-button.tsx
@@ -31,7 +31,10 @@ export default function UserButton() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <div className="rounded-full border-2 border-solid border-slate-500 hover:border-slate-200">
+        <div
+          className="rounded-full border-2 border-solid border-slate-500 hover:border-slate-200"
+          data-testid="avatarCtxMenu"
+        >
           <UserAvatar image={session.user.image ?? null} size={8} />
         </div>
       </DropdownMenuTrigger>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
+// const envSchema = z.object({
+//   DISCORD_WEBHOOK_URL: z.string().url().optional(),
+// });
 const envSchema = z.object({
-  DISCORD_WEBHOOK_URL: z.string().url().optional(),
+  DISCORD_WEBHOOK_URL: z.string().url().optional().or(z.literal("")),
 });
 
 const env = envSchema.safeParse(process.env);

--- a/tests/e2e/cache.spec.ts
+++ b/tests/e2e/cache.spec.ts
@@ -1,0 +1,69 @@
+import { expect, Page, test } from "@playwright/test";
+
+/**
+ * FIRST, CHECK THIS URL ADDRESS AND TIMEOUT IN playwright.config.ts
+ */
+
+const URL = "http://localhost:3001/";
+// const URL = "http://localhost:3000/";
+
+test.describe("Czechibank cache update", () => {
+  async function loopLoginLogout(page: Page) {
+    const timeout = 100;
+    const firstUserName = "[BRNO] Pejsek a Kočička 🐶&🐱";
+    await expect(page).toHaveTitle(/CzechiBank/);
+
+    // LOGIN FIRST USER
+    await page.getByLabel("Email").fill("zachranNas+brno@pejsekAKocicka.cz");
+    await page.getByLabel("Password").fill("PejsekAKocicka123");
+    await page.locator("form").getByRole("button", { name: "Sign in" }).click();
+    await page.waitForTimeout(timeout);
+    await expect(page.getByRole("heading", { name: firstUserName })).toBeVisible();
+
+    // SEE PROFILE PAGE OF FIRST USER
+    await page.getByTestId("avatarCtxMenu").click();
+    await page.getByRole("button", { name: "Profile" }).click();
+    const actualName = page.getByTestId("userName");
+    console.log("actualName first: ", await actualName.textContent());
+    console.log("firstUserName first: ", firstUserName);
+    await page.waitForTimeout(timeout);
+    await expect(actualName).toHaveText(firstUserName);
+
+    // LOGOUT THE FIRST USER
+    await page.getByTestId("avatarCtxMenu").click();
+    await page.getByRole("button", { name: "Sign Out" }).click();
+
+    // LOGIN SECOND USER
+    const secondUserName = "Simona Humpolová";
+    await page.getByLabel("Email").fill("simona@czechibank.ostrava.digital");
+    await page.getByLabel("Password").fill("hello123456");
+    await page.locator("form").getByRole("button", { name: "Sign in" }).click();
+    await page.waitForTimeout(timeout);
+    await expect(page.getByRole("heading", { name: secondUserName })).toBeVisible();
+
+    // SEE PROFILE PAGE OF SECOND USER
+    await page.getByTestId("avatarCtxMenu").click();
+    await page.getByRole("button", { name: "Profile" }).click();
+    const actualNameSecond = page.getByTestId("userName");
+    console.log("actualName first: ", await actualNameSecond.textContent());
+    console.log("firstUserName first: ", secondUserName);
+    await page.waitForTimeout(timeout);
+    await expect(actualName).toHaveText(secondUserName);
+
+    // LOGOUT THE SECOND USER
+    await page.getByTestId("avatarCtxMenu").click();
+    await page.getByRole("button", { name: "Sign Out" }).click();
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(URL);
+  });
+
+  test("Check cache update", async ({ page }) => {
+    for (let i = 0; i < 30; i++) {
+      await loopLoginLogout(page);
+    }
+
+    await page.pause();
+  });
+});


### PR DESCRIPTION
use of window.location.replace("/"); to clear cache in order to prevent signed out user to access pages which only signed in user shoudl see 

(optionally I used router.replace('/') but it seemed to solve the issue only partially, when clicking back/forward btns I clould still access bankAccount/[id] page