### PR TITLE
[CZBANK-76] bug: set correct initial balance for new BA

### DIFF
--- a/prisma/migrations/20250916164538_set_ba_default_balance_to_0/migration.sql
+++ b/prisma/migrations/20250916164538_set_ba_default_balance_to_0/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BankAccount" ALTER COLUMN "balance" SET DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,7 @@ model BankAccount {
   name            String
   currency        Currency      @default(CZECHITOKEN)
   userId          String
-  balance         Float         @default(100000)
+  balance         Float         @default(0)
   isActive        Boolean       @default(true)
   user            User          @relation(fields: [userId], references: [id])
   outTransactions Transaction[] @relation("FromAccount")

--- a/src/domain/bankAccount-domain/ba-helpers.ts
+++ b/src/domain/bankAccount-domain/ba-helpers.ts
@@ -12,6 +12,11 @@ export async function enforceMinActiveBankAccount(userId: string) {
   }
 }
 
+export async function getInitialBalanceForUser(userId: string): Promise<number> {
+  const { total } = await repository.getBankAccountsByUserId(userId, { page: 1, limit: 1 });
+  return total === 0 ? 100_000 : 0;
+}
+
 export async function enforceZeroBalance(bankAccount: BankAccount) {
   if (!bankAccount) {
     throw {

--- a/src/domain/bankAccount-domain/ba-repository.ts
+++ b/src/domain/bankAccount-domain/ba-repository.ts
@@ -66,16 +66,19 @@ export async function createBankAccount({
   userId,
   currency,
   name = "My Bank Account",
+  balance,
 }: {
   userId: string;
   currency: Currency;
   name?: string;
+  balance: number;
 }) {
   const bankAccount = await prisma.bankAccount.create({
     data: {
       userId: userId,
       currency: currency,
       name: name,
+      balance,
       number: generateRandomDigits(12) + "/5555",
       isActive: true,
     },

--- a/src/domain/bankAccount-domain/ba-service.ts
+++ b/src/domain/bankAccount-domain/ba-service.ts
@@ -1,6 +1,11 @@
 import { ApiErrorCode, ErrorResponse, errorResponse, SuccessResponse, successResponse } from "@/lib/response";
 import { BankAccount } from "@prisma/client";
-import { enforceMinActiveBankAccount, enforceZeroBalance, getUniqueBankAccountName } from "./ba-helpers";
+import {
+  enforceMinActiveBankAccount,
+  enforceZeroBalance,
+  getInitialBalanceForUser,
+  getUniqueBankAccountName,
+} from "./ba-helpers";
 import * as repository from "./ba-repository";
 
 type Pagination = {
@@ -14,7 +19,10 @@ const bankAccountService = {
   ): Promise<SuccessResponse<BankAccount> | ErrorResponse> {
     try {
       const finalName = await getUniqueBankAccountName(bankAccount.name, bankAccount.userId);
-      const result = await repository.createBankAccount({ ...bankAccount, name: finalName });
+
+      const initialBalance = await getInitialBalanceForUser(bankAccount.userId);
+
+      const result = await repository.createBankAccount({ ...bankAccount, name: finalName, balance: initialBalance });
       return successResponse("Bank account created successfully", result);
     } catch (error: any) {
       return errorResponse(error?.message || "Failed to create bank account", ApiErrorCode.INTERNAL_ERROR);


### PR DESCRIPTION
The initial bank account created with user registration needs to have initial balance 100 000 CZT
Every next BA created by the user needs to be created with balance 0 CZK
Details:
- default balance for BankAccount in prisma model set to 0
- new ba-helper function created to set initial balance of new account at creation based on the following rule>
      - if at creation of new BA the total count of BAs in user account = 0, we set BA initial balance to 100k (this happens only at user registration) else set BA balance to 0 CZT
      - as we already have in place a rule that ensures user can never erase all of their BAs they should only receive 100k balance at registration, all other created BAs will have 0 CZT balance
- helper fn implemented in service and repo layer