### PR TITLE
CZBANK-23 - adding two new features

### DIFF
--- a/src/app/api/v1/bank-account/[id]/route.ts
+++ b/src/app/api/v1/bank-account/[id]/route.ts
@@ -1,8 +1,11 @@
 import { checkUserAuthOrThrowError } from "@/app/api/v1/server-actions";
 import { RenameBankAccountSchema } from "@/domain/bankAccount-domain/ba-schema";
 import bankAccountService from "@/domain/bankAccount-domain/ba-service";
+import { canSeeYourBankAccountDetailFeature as anyOneCanSeeYourBankAccountFeature } from "@/domain/features-domain/features-application-service";
+import featuresService from "@/domain/features-domain/features-service";
 import { mapErrorCodeToStatus } from "@/lib/api-error-status-map";
-import { ApiErrorCode, successResponse, validateEventHandler } from "@/lib/response";
+import { ApiErrorCode, ErrorResponse, SuccessResponse, successResponse, validateEventHandler } from "@/lib/response";
+import type { BankAccount } from "@prisma/client";
 import { z } from "zod";
 import { ApiError, handleErrors } from "../../routes";
 
@@ -197,7 +200,7 @@ import { ApiError, handleErrors } from "../../routes";
 export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
   try {
     console.log("GET /bank-account/[id]/route.ts");
-
+    let bankAccountResponse: SuccessResponse<BankAccount> | ErrorResponse;
     const { id } = await context.params;
     const schema = z.object({
       id: z.string().cuid(),
@@ -211,8 +214,14 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
     const user = await checkUserAuthOrThrowError(request);
     if ("error" in user) return Response.json(user, { status: mapErrorCodeToStatus(user.error.code) }); // UNAUTHORIZED(401)
 
-    const bankAccountResponse = await bankAccountService.getBankAccountById(parsedId.id, user.id);
-
+    // If the feature is enabled, dont check who is owner of the bank account
+    const allFeatures = await featuresService.server.getAllFeatures();
+    if (allFeatures.success && anyOneCanSeeYourBankAccountFeature(allFeatures.data)) {
+      bankAccountResponse = await bankAccountService.getBankAccountById(parsedId.id);
+    } else {
+      // If the feature is disabled, also check who is owner of the bank account
+      bankAccountResponse = await bankAccountService.getBankAccountByIdAndUserId(parsedId.id, user.id);
+    }
     if ("error" in bankAccountResponse)
       return Response.json(bankAccountResponse, { status: mapErrorCodeToStatus(bankAccountResponse.error.code) }); // NOT_FOUND(404)
 
@@ -236,7 +245,7 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
     if ("error" in user) return Response.json(user, { status: mapErrorCodeToStatus(user.error.code) }); // UNAUTHORIZED(401)
 
     // First verify the user owns this account
-    const bankAccountResponse = await bankAccountService.getBankAccountById(id, user.id);
+    const bankAccountResponse = await bankAccountService.getBankAccountByIdAndUserId(id, user.id);
     if ("error" in bankAccountResponse)
       return Response.json(bankAccountResponse, { status: mapErrorCodeToStatus(bankAccountResponse.error.code) }); // NOT_FOUND(404)
 
@@ -284,7 +293,7 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
     if ("error" in user) return Response.json(user, { status: mapErrorCodeToStatus(user.error.code) });
     // UNAUTHORIZED(401)
 
-    const bankAccountResponse = await bankAccountService.getBankAccountById(id, user.id);
+    const bankAccountResponse = await bankAccountService.getBankAccountByIdAndUserId(id, user.id);
     if ("error" in bankAccountResponse)
       return Response.json(bankAccountResponse, { status: mapErrorCodeToStatus(bankAccountResponse.error.code) }); // NOT_FOUND(404)
 

--- a/src/app/api/v1/server-actions.ts
+++ b/src/app/api/v1/server-actions.ts
@@ -15,17 +15,22 @@ export async function checkUserAuthOrThrowError(
     return errorResponse("Unauthorized", ApiErrorCode.UNAUTHORIZED);
   }
 
-  const session = await userService.server.getSession(
-    new Headers({
-      "x-api-key": apiKey,
-    }),
-  );
+  try {
+    const session = await userService.server.getSession(
+      new Headers({
+        "x-api-key": apiKey,
+      }),
+    );
 
-  if (!session) {
+    if (!session) {
+      return errorResponse("Unauthorized", ApiErrorCode.UNAUTHORIZED);
+    }
+
+    return session.user;
+  } catch (error) {
+    console.error("[checkUserAuthOrThrowError] Auth error:", error);
     return errorResponse("Unauthorized", ApiErrorCode.UNAUTHORIZED);
   }
-
-  return session.user;
 }
 
 export async function generateRequestId(): Promise<string> {

--- a/src/app/bankAccount/[id]/page.tsx
+++ b/src/app/bankAccount/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function BankAccountPage(props: { params: Promise<{ id: str
   if (!session) {
     redirect("/signin");
   }
-  const bankAccount = await bankAccountService.getBankAccountById(params.id, session.user.id);
+  const bankAccount = await bankAccountService.getBankAccountByIdAndUserId(params.id, session.user.id);
   if (!bankAccount.success) {
     notFound();
   }

--- a/src/components/transactions/transfer.tsx
+++ b/src/components/transactions/transfer.tsx
@@ -9,6 +9,7 @@ import { FeatureType } from "@/domain/features-domain/features.schema";
 import { sendMoneyToBankNumberAction } from "@/domain/transaction-domain/transaction-action";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Prisma } from "@prisma/client";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "../ui/button";
@@ -16,6 +17,10 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { Input } from "../ui/input";
 import { useToast } from "../ui/use-toast";
 import { UserAvatar } from "../user/avatar";
+
+function Spinner() {
+  return <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white"></div>;
+}
 
 export type UserWithBankAccounts = Prisma.UserGetPayload<{
   include: {
@@ -38,6 +43,7 @@ export function TransactionTransfer({
 }) {
   console.log(userId, bankAccountNumber, balance);
   const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
   const users = allUsers
     .filter((user) => user.id !== userId)
     .sort((a, b) => {
@@ -69,37 +75,47 @@ export function TransactionTransfer({
   });
 
   const action: () => void = form.handleSubmit(async (data) => {
-    const response = await sendMoneyToBankNumberAction({
-      amount: data.amount,
-      currency: "CZECHITOKEN",
-      fromBankNumber: bankAccountNumber,
-      toBankNumber: data.toBankNumber,
-      userId: userId,
-      applicationType: "web",
-    });
+    setIsLoading(true);
+    try {
+      const response = await sendMoneyToBankNumberAction({
+        amount: data.amount,
+        currency: "CZECHITOKEN",
+        fromBankNumber: bankAccountNumber,
+        toBankNumber: data.toBankNumber,
+        userId: userId,
+        applicationType: "web",
+      });
 
-    if (response.success) {
-      if (showGifInTransactionsFeature(features)) {
-        toast({
-          title: "💸 Transaction created!",
-          description: (
-            <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGw2OXB2cmMydW1kb3k5cnpub2x4bm02bmhzZm9lb3E3ZTRxdnhwNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HFkA6omUyjVYqw8/giphy.gif" />
-          ),
-        });
+      if (response.success) {
+        if (showGifInTransactionsFeature(features)) {
+          toast({
+            title: "💸 Transaction created!",
+            description: (
+              <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGw2OXB2cmMydW1kb3k5cnpub2x4bm02bmhzZm9lb3E3ZTRxdnhwNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HFkA6omUyjVYqw8/giphy.gif" />
+            ),
+          });
+        } else {
+          toast({
+            title: "💸 Transaction created!",
+          });
+        }
       } else {
         toast({
-          title: "💸 Transaction created!",
+          title: "💸 Transaction failed!",
+          description: response.error.message,
         });
       }
-    } else {
+
+      form.resetField("amount");
+      form.resetField("toBankNumber");
+    } catch (error) {
       toast({
         title: "💸 Transaction failed!",
-        description: response.error.message,
+        description: error instanceof Error ? error.message : "Unknown error occurred",
       });
+    } finally {
+      setIsLoading(false);
     }
-
-    form.resetField("amount");
-    form.resetField("toBankNumber");
   });
   return (
     <div className="flex flex-col gap-4">
@@ -154,7 +170,9 @@ export function TransactionTransfer({
             )}
           />
 
-          <Button type="submit">Transfer</Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? <Spinner /> : "Transfer"}
+          </Button>
         </form>
       </Form>
     </div>

--- a/src/components/transactions/transfer.tsx
+++ b/src/components/transactions/transfer.tsx
@@ -105,15 +105,14 @@ export function TransactionTransfer({
           description: response.error.message,
         });
       }
-
-      form.resetField("amount");
-      form.resetField("toBankNumber");
     } catch (error) {
       toast({
         title: "💸 Transaction failed!",
         description: error instanceof Error ? error.message : "Unknown error occurred",
       });
     } finally {
+      form.resetField("amount");
+      form.resetField("toBankNumber");
       setIsLoading(false);
     }
   });

--- a/src/domain/bankAccount-domain/ba-repository.ts
+++ b/src/domain/bankAccount-domain/ba-repository.ts
@@ -112,6 +112,18 @@ export async function getBankAccountByIdAndUserId(bankAccountId: string, userId:
   return bankAccount;
 }
 
+export async function getBankAccountById(bankAccountId: string) {
+  console.log(bankAccountId);
+  const bankAccount = await prisma.bankAccount.findFirst({
+    where: {
+      id: bankAccountId,
+      isActive: true,
+    },
+  });
+
+  return bankAccount;
+}
+
 export async function getBankAccountByNumber(bankNumber: string) {
   const bankAccount = await prisma.bankAccount.findFirst({
     where: {

--- a/src/domain/bankAccount-domain/ba-repository.ts
+++ b/src/domain/bankAccount-domain/ba-repository.ts
@@ -113,7 +113,6 @@ export async function getBankAccountByIdAndUserId(bankAccountId: string, userId:
 }
 
 export async function getBankAccountById(bankAccountId: string) {
-  console.log(bankAccountId);
   const bankAccount = await prisma.bankAccount.findFirst({
     where: {
       id: bankAccountId,

--- a/src/domain/bankAccount-domain/ba-service.ts
+++ b/src/domain/bankAccount-domain/ba-service.ts
@@ -29,9 +29,18 @@ const bankAccountService = {
     }
   },
 
-  async getBankAccountById(id: string, userId: string) {
+  async getBankAccountByIdAndUserId(id: string, userId: string) {
     const bankAccount = await repository.getBankAccountByIdAndUserId(id, userId);
 
+    if (!bankAccount) {
+      return errorResponse("Bank account not found", ApiErrorCode.NOT_FOUND);
+    }
+
+    return successResponse("Bank account retrieved successfully", bankAccount);
+  },
+
+  async getBankAccountById(id: string) {
+    const bankAccount = await repository.getBankAccountById(id);
     if (!bankAccount) {
       return errorResponse("Bank account not found", ApiErrorCode.NOT_FOUND);
     }

--- a/src/domain/features-domain/features-application-service.ts
+++ b/src/domain/features-domain/features-application-service.ts
@@ -25,3 +25,7 @@ export function showGifInTransactionsFeature(features: FeatureType[]): boolean {
 export function increaseTimeInSendingTransactionsFeature(features: FeatureType[]): boolean {
   return featuresService.client.getFeatureToggle(FeaturesKeysEnum.INCREASE_TIME_IN_SENDING_TRANSACTIONS, features);
 }
+
+export function canSeeYourBankAccountDetailFeature(features: FeatureType[]): boolean {
+  return featuresService.client.getFeatureToggle(FeaturesKeysEnum.CAN_SEE_YOUR_BANK_ACCOUNT_DETAIL, features);
+}

--- a/src/domain/features-domain/features-application-service.ts
+++ b/src/domain/features-domain/features-application-service.ts
@@ -21,3 +21,7 @@ export function amountSchemaToCheckFeature(features: FeatureType[], balance: num
 export function showGifInTransactionsFeature(features: FeatureType[]): boolean {
   return featuresService.client.getFeatureToggle(FeaturesKeysEnum.GIFS_IN_TRANSACTIONS, features);
 }
+
+export function increaseTimeInSendingTransactionsFeature(features: FeatureType[]): boolean {
+  return featuresService.client.getFeatureToggle(FeaturesKeysEnum.INCREASE_TIME_IN_SENDING_TRANSACTIONS, features);
+}

--- a/src/domain/features-domain/features.schema.ts
+++ b/src/domain/features-domain/features.schema.ts
@@ -29,6 +29,14 @@ export const availableFeatures: Omit<FeatureType, "id">[] = [
     defaultToggle: false,
     category: ["BUG", "UI", "BANK_ACCOUNT"],
   },
+  {
+    key: "INCREASE_TIME_IN_SENDING_TRANSACTIONS",
+    name: "Increase time in sending transactions",
+    description: "Increase time in sending transactions.",
+    toggle: false,
+    defaultToggle: false,
+    category: ["BUG"],
+  },
 ];
 
 export const FeatureSchema = z.object({

--- a/src/domain/features-domain/features.schema.ts
+++ b/src/domain/features-domain/features.schema.ts
@@ -27,7 +27,7 @@ export const availableFeatures: Omit<FeatureType, "id">[] = [
     description: "Show an incorrect account balance (simulate calculation bug).",
     toggle: false,
     defaultToggle: false,
-    category: ["BUG", "UI", "BANK_ACCOUNT"],
+    category: ["BUG", "UI", "BANK_ACCOUNT", "API"],
   },
   {
     key: "INCREASE_TIME_IN_SENDING_TRANSACTIONS",
@@ -36,6 +36,15 @@ export const availableFeatures: Omit<FeatureType, "id">[] = [
     toggle: false,
     defaultToggle: false,
     category: ["BUG"],
+  },
+  {
+    key: "CAN_SEE_YOUR_BANK_ACCOUNT_DETAIL",
+    name: "Can see your bank account balance",
+    description:
+      "Can see your bank account detail. If disabled, only the owner can see the. `GET v1/bank-account/{id}`",
+    toggle: false,
+    defaultToggle: false,
+    category: ["BUG", "BANK_ACCOUNT", "API", "SECURITY"],
   },
 ];
 

--- a/src/domain/transaction-domain/transaction-service.ts
+++ b/src/domain/transaction-domain/transaction-service.ts
@@ -8,8 +8,6 @@ import { sendDiscordMessage } from "../social-reporting-domain/discord-action";
 import * as repository from "./transaction-repository";
 import { CreateTransactionNumberToNumberSchema } from "./transation-schema";
 
-const allFeatures = await featuresService.server.getAllFeatures();
-
 function parseTransactionData(
   userId: string,
   fromBankNumber: string,
@@ -57,6 +55,8 @@ const transactionService = {
     applicationType: "api" | "web";
   }) {
     try {
+      const allFeatures = await featuresService.server.getAllFeatures();
+
       if (allFeatures.success) {
         if (increaseTimeInSendingTransactionsFeature(allFeatures.data)) {
           await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/src/domain/transaction-domain/transaction-service.ts
+++ b/src/domain/transaction-domain/transaction-service.ts
@@ -2,9 +2,13 @@ import env from "@/lib/env";
 import { ApiErrorCode, errorResponse, successResponse } from "@/lib/response";
 import { Currency } from "@prisma/client";
 import bankAccountService from "../bankAccount-domain/ba-service";
+import { increaseTimeInSendingTransactionsFeature } from "../features-domain/features-application-service";
+import featuresService from "../features-domain/features-service";
 import { sendDiscordMessage } from "../social-reporting-domain/discord-action";
 import * as repository from "./transaction-repository";
 import { CreateTransactionNumberToNumberSchema } from "./transation-schema";
+
+const allFeatures = await featuresService.server.getAllFeatures();
 
 function parseTransactionData(
   userId: string,
@@ -53,6 +57,12 @@ const transactionService = {
     applicationType: "api" | "web";
   }) {
     try {
+      if (allFeatures.success) {
+        if (increaseTimeInSendingTransactionsFeature(allFeatures.data)) {
+          await new Promise((resolve) => setTimeout(resolve, 5000));
+        }
+      }
+
       const parsedTransaction = parseTransactionData(userId, fromBankNumber, toBankNumber, amount, currency);
 
       if ("error" in parsedTransaction) {


### PR DESCRIPTION
feature: adding delay 5 second in creating new transaction
feature: bug in security - authorized user can check others bank account details
fix: fix for better-auth - if API key was invalid, server returned 500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds feature flags to delay transactions and control bank-account detail visibility, refactors account lookups to enforce ownership, improves auth error handling, and adds loading state to transfer UI.
> 
> - **Backend/API**:
>   - **Bank Account routes**: `GET /api/v1/bank-account/{id}` now conditionally bypasses ownership via `CAN_SEE_YOUR_BANK_ACCOUNT_DETAIL`; otherwise uses `getBankAccountByIdAndUserId`. `DELETE`/`PATCH` enforce ownership via `getBankAccountByIdAndUserId`.
>   - **Services/Repo**: Add `repository.getBankAccountById(id)` and `service.getBankAccountById(id)`; rename `service.getBankAccountByIdAndUserId` for ownership checks.
>   - **Auth**: `checkUserAuthOrThrowError` wrapped in try/catch to return `UNAUTHORIZED` on errors instead of 500.
>   - **Transactions**: When `INCREASE_TIME_IN_SENDING_TRANSACTIONS` is enabled, add a 5s delay before processing.
> - **Features**:
>   - Add `INCREASE_TIME_IN_SENDING_TRANSACTIONS` and `CAN_SEE_YOUR_BANK_ACCOUNT_DETAIL`; expand categories for `BUG_INCORRECT_BALANCE_DISPLAY`.
> - **Frontend**:
>   - Bank account page uses `getBankAccountByIdAndUserId` for ownership enforcement.
>   - Transfer form: add loading state with spinner, disable submit during processing; improved success/failure toasts and field reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498e3b42eb1672982162e4f4f428551d43468fa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->