### PR TITLE
CZBANK-41 : Fixing new default name of bank account

### DIFF
--- a/scripts/seed-helpers/validation.ts
+++ b/scripts/seed-helpers/validation.ts
@@ -35,6 +35,21 @@ export default async function validateSeedBankAccounts(prisma: PrismaClient, use
     console.error(`[seed-users] Duplicate bank account numbers in seed file: ${[...new Set(dup)].join(", ")}`);
     throw new Error("Seed contains duplicate bank account numbers. Fix usersToSeed before running.");
   }
+  // Validate that primaryBalanceIndex and primaryTransactionIndex point to real array entries
+  usersToSeed.forEach((u) => {
+    const accountCount = Array.isArray(u.bankAccountNumber) ? u.bankAccountNumber.length : 1;
+
+    if (u.primaryBalanceIndex !== undefined && u.primaryBalanceIndex >= accountCount) {
+      throw new Error(
+        `User ${u.email} has primaryBalanceIndex ${u.primaryBalanceIndex} but only has ${accountCount} accounts.`,
+      );
+    }
+    if (u.primaryTransactionIndex !== undefined && u.primaryTransactionIndex >= accountCount) {
+      throw new Error(
+        `User ${u.email} has primaryTransactionIndex ${u.primaryTransactionIndex} but only has ${accountCount} accounts.`,
+      );
+    }
+  });
 
   // Check for conflicts with other users already in the DB
   if (allProvidedBAs.length > 0) {

--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -69,6 +69,8 @@ export type UserSeedConfig = {
   skipApiKey?: boolean; // Don't create any API keys
   needsTransactionHistory?: boolean; // Mark user for transaction history generation
   transactionCount?: number; // Number of transactions for this user
+  primaryBalanceIndex?: number; // Which BA gets the 100k/Seed balance (Default BA index: 0)
+  primaryTransactionIndex?: number; // Which BA gets involved in the 10,000 seed transactions (Default BA index: 0)
 };
 
 export const adminUserToSeed: Omit<

--- a/src/app/api/v1/bank-account/create/route.ts
+++ b/src/app/api/v1/bank-account/create/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: Request) {
     const result = await bankAccountService.createBankAccount({
       userId: user.id,
       currency: parsedBody.data.currency,
-      name: parsedBody.data.name || "New Bank Account",
+      name: parsedBody.data.name,
     });
 
     return NextResponse.json(successResponse("Bank account created successfully", { bankAccount: result }), {

--- a/src/domain/bankAccount-domain/ba-helpers.ts
+++ b/src/domain/bankAccount-domain/ba-helpers.ts
@@ -53,5 +53,5 @@ export async function getUniqueBankAccountName(
 
   let nextNumber = 1;
   while (used.has(nextNumber)) nextNumber++;
-  return `${baseName}(${String(nextNumber).padStart(2, "0")})`;
+  return `${baseName} (${String(nextNumber).padStart(2, "0")})`;
 }

--- a/src/domain/bankAccount-domain/ba-repository.ts
+++ b/src/domain/bankAccount-domain/ba-repository.ts
@@ -79,13 +79,6 @@ export async function createBankAccount({
   const MAX_ATTEMPTS = 6;
   let lastError: any = null;
 
-  // checking how many bank accounts the user has
-  const bankAccountsCount = await prisma.bankAccount.count({
-    where: { userId },
-  });
-
-  name = name === "My Bank Account" ? `My Bank Account (${bankAccountsCount + 1})` : name;
-
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     //if BA number is provided (seeded users), use it, otherwise random generation
     const candidateNumber = number ?? generateRandomDigits(12) + "/5555";

--- a/src/domain/bankAccount-domain/ba-repository.ts
+++ b/src/domain/bankAccount-domain/ba-repository.ts
@@ -79,6 +79,13 @@ export async function createBankAccount({
   const MAX_ATTEMPTS = 6;
   let lastError: any = null;
 
+  // checking how many bank accounts the user has
+  const bankAccountsCount = await prisma.bankAccount.count({
+    where: { userId },
+  });
+
+  name = name === "My Bank Account" ? `My Bank Account (${bankAccountsCount + 1})` : name;
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     //if BA number is provided (seeded users), use it, otherwise random generation
     const candidateNumber = number ?? generateRandomDigits(12) + "/5555";

--- a/src/domain/bankAccount-domain/ba-schema.ts
+++ b/src/domain/bankAccount-domain/ba-schema.ts
@@ -1,6 +1,7 @@
 import { Currency } from "@prisma/client";
 import { z } from "zod";
 
+// Default schema for bank account creation - name is optional
 export const BankAccountSchema = z.object({
   name: z.string().optional(),
   currency: z.nativeEnum(Currency),

--- a/src/domain/bankAccount-domain/ba-service.ts
+++ b/src/domain/bankAccount-domain/ba-service.ts
@@ -15,10 +15,10 @@ type Pagination = {
 
 const bankAccountService = {
   async createBankAccount(
-    bankAccount: Pick<BankAccount, "userId" | "currency" | "name"> & { number?: string; balance?: number },
+    bankAccount: Pick<BankAccount, "userId" | "currency"> & { name?: string; number?: string; balance?: number },
   ): Promise<SuccessResponse<BankAccount> | ErrorResponse> {
     try {
-      const finalName = await getUniqueBankAccountName(bankAccount.name, bankAccount.userId);
+      const finalName = await getUniqueBankAccountName(bankAccount.name || "My Bank Account", bankAccount.userId);
 
       const balanceToSet =
         bankAccount.balance !== undefined ? bankAccount.balance : await getInitialBalanceForUser(bankAccount.userId);


### PR DESCRIPTION
Small changes in @silviczka PR -

`1. bank account -> Trololo, 2. bank account -> Trololo (01), etc.. Bobobo -> Bobobo (01), etc..`

I made the name optional in bank account service and handle name there, if name is optional in API. 

<img width="1030" height="1266" alt="image" src="https://github.com/user-attachments/assets/f01246fc-6189-4b23-a439-d6f5a908dd26" />
^^ Trololo bank accounts represent current state

Please merge #34 first :) 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bank account naming updates**
> 
> - `BankAccountSchema` now makes `name` optional; API create route no longer applies a fallback and forwards provided `name`
> - Service `createBankAccount` accepts optional `name`, defaults to `"My Bank Account"`, and ensures uniqueness
> - Unique name format changed to `"Base (NN)"` (adds a space before parentheses)
> 
> **Seeding enhancements**
> 
> - `UserSeedConfig` adds optional `primaryBalanceIndex` and `primaryTransactionIndex`
> - Validation checks these indices are within the provided bank account array bounds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c8c39bb62ac52853d3cb5904c045cf768ba6bf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->