### PR TITLE
CZBANK-46 - fixing `user/create` endpoint 

### DIFF
--- a/src/app/api/v1/user/create/route.ts
+++ b/src/app/api/v1/user/create/route.ts
@@ -3,7 +3,7 @@ export { DELETE, HEAD, OPTIONS, PATCH, PUT } from "../../routes";
 import apikeyService from "@/domain/apikey/apikey-service";
 import { UserSchema } from "@/domain/user-domain/user-schema";
 import userService from "@/domain/user-domain/user-service";
-import { validateEventHandler } from "@/lib/response";
+import { ApiErrorCode, errorResponse, successResponse, validateEventHandler } from "@/lib/response";
 import { APIError } from "better-auth/api";
 import { ApiError, handleErrors } from "../../routes";
 
@@ -12,7 +12,7 @@ import { ApiError, handleErrors } from "../../routes";
  * /user/create:
  *   post:
  *     summary: Create a new user
- *     description: Creates a new user account with the provided details
+ *     description: Creates a new user account with the provided details and automatically generates an API key
  *     tags: [Users]
  *     requestBody:
  *       required: true
@@ -26,17 +26,34 @@ import { ApiError, handleErrors } from "../../routes";
  *         content:
  *           application/json:
  *             schema:
- *               allOf:
- *                 - $ref: '#/components/schemas/SuccessResponse'
- *                 - type: object
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 message:
+ *                   type: string
+ *                   example: "User created successfully"
+ *                 data:
+ *                   $ref: '#/components/schemas/User'
+ *                 meta:
+ *                   type: object
  *                   properties:
- *                     data:
- *                       type: object
- *                       properties:
- *                         user:
- *                           $ref: '#/components/schemas/User'
+ *                     timestamp:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2026-01-10T22:53:51.562Z"
+ *                       description: Response timestamp
+ *                   required:
+ *                     - timestamp
  *       400:
  *         description: Invalid input or email already exists
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       422:
+ *         description: Validation error
  *         content:
  *           application/json:
  *             schema:
@@ -59,7 +76,9 @@ export async function POST(request: Request) {
     const createdUser = await userService.server.createUser(parsedUser, "user");
     const apiKey = await apikeyService.server.createApiKey(createdUser.user.id);
 
-    return Response.json({ ...createdUser.user, apiKey: apiKey.key }, { status: 201 });
+    return Response.json(successResponse("User created successfully", { ...createdUser.user, apiKey: apiKey.key }), {
+      status: 201,
+    });
   } catch (error) {
     // TODO: @vojtech-cerveny - handle better-auth - we can reuse their ApiErrorCodes etc.
     // https://www.better-auth.com/docs/concepts/api#error-handling
@@ -71,7 +90,12 @@ export async function POST(request: Request) {
     if (error instanceof ApiError || error instanceof APIError) {
       return handleErrors(error);
     } else {
-      return Response.json({ error: "Internal Server Error", message: error }, { status: 500 });
+      return Response.json(
+        errorResponse("Internal Server Error", ApiErrorCode.INTERNAL_ERROR, [
+          { code: ApiErrorCode.INTERNAL_ERROR, message: error instanceof Error ? error.message : "Unknown error" },
+        ]),
+        { status: 500 },
+      );
     }
   }
 }

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -58,21 +58,21 @@ All responses follow a consistent format:
         User: {
           type: "object",
           properties: {
-            id: { type: "string", example: "bFNcCQmAYJ2u4fODHT09QgLB7vkeSfhv", description: "Unique user identifier" },
-            name: { type: "string", example: "John Doe", description: "User's full name" },
-            email: { type: "string", example: "user@example.com", description: "User's email address" },
+            id: { type: "string", example: "bYmjHnHasQisW4g6L2IPxwLHBQYwHsLU", description: "Unique user identifier" },
+            name: { type: "string", example: "Jana Nováková", description: "User's full name" },
+            email: { type: "string", example: "jana@example.com", description: "User's email address" },
             emailVerified: { type: "boolean", example: false, description: "Whether the user's email is verified" },
             image: { type: ["string", "null"], example: null, description: "URL to user's profile image or null" },
             createdAt: {
               type: "string",
               format: "date-time",
-              example: "2025-07-21T12:27:03.625Z",
+              example: "2026-01-10T22:53:50.315Z",
               description: "When the user was created",
             },
             updatedAt: {
               type: "string",
               format: "date-time",
-              example: "2025-07-21T12:27:03.625Z",
+              example: "2026-01-10T22:53:50.315Z",
               description: "When the user was last updated",
             },
             role: {
@@ -82,9 +82,9 @@ All responses follow a consistent format:
               description: "User's role (user or admin)",
             },
             banned: {
-              type: ["boolean", "null"],
-              example: null,
-              description: "Whether the user is banned (null if not set)",
+              type: "boolean",
+              example: false,
+              description: "Whether the user is banned",
             },
             banReason: {
               type: ["string", "null"],
@@ -97,8 +97,13 @@ All responses follow a consistent format:
               example: null,
               description: "Ban expiration date if banned, otherwise null",
             },
+            apiKey: {
+              type: ["string", "null"],
+              example: "YUNKOBkSooRIXDgSSwYZgjPcAhTzqfIcGLvvFiODAmfdgfyrxQPuCRGsaDEYulQi",
+              description: "API key created for the user (only included in user creation response, null otherwise)",
+            },
           },
-          required: ["id", "name", "email", "emailVerified", "createdAt", "updatedAt", "role"],
+          required: ["id", "name", "email", "emailVerified", "createdAt", "updatedAt", "role", "banned"],
         },
         UserCreate: {
           type: "object",


### PR DESCRIPTION
fixing documentation + update responses from the endpoint. 

<img width="624" height="563" alt="Screenshot 2026-01-11 at 00 06 06" src="https://github.com/user-attachments/assets/a3060553-3ab1-47d7-808a-a0b86409a2d7" />
<img width="564" height="318" alt="Screenshot 2026-01-11 at 00 05 57" src="https://github.com/user-attachments/assets/1fafc0ec-1f4e-4e97-80ae-9d0a0952d421" />
<img width="641" height="512" alt="Screenshot 2026-01-11 at 00 05 43" src="https://github.com/user-attachments/assets/681ad738-7b99-4369-aa80-b7fda68d147e" />
<img width="450" height="429" alt="Screenshot 2026-01-11 at 00 05 16" src="https://github.com/user-attachments/assets/99c0d594-d527-45d7-b132-b1b77242f535" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the `user/create` endpoint with the app-wide response format and updates API documentation.
> 
> - Wraps success payload in `successResponse` (includes `message`, `data`, `meta.timestamp`) and returns created `User` plus generated `apiKey`
> - Unifies server errors via `errorResponse` with `ApiErrorCode`; keeps `ApiError`/`APIError` passthrough; adds 422 handling for validation
> - Swagger: updates 201 response schema to the standardized success envelope; adds 422 response; clarifies description (auto-generates API key)
> - Swagger `User` schema tweaks: updated examples, `banned` is now boolean and required; adds optional `apiKey` (only in creation response)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2104eb355a185dff1e40922ee7bbad253ba9d5c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->