### PR TITLE
CZBANK-84: Link in Czechibank API Documentation can't be reached

### DIFF
--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -8,7 +8,11 @@ export async function GET(request: Request) {
 
   // If accessed from a browser, redirect to the UI page
   if (accept.includes("text/html")) {
-    return NextResponse.redirect(new URL("/api/v1/docs/page", request.url));
+    // Construct the redirect URL using headers to handle proxies/load balancers correctly
+    const host = headersList.get("x-forwarded-host") || headersList.get("host") || request.url;
+    const protocol = headersList.get("x-forwarded-proto") || "https";
+    const redirectUrl = new URL("/api/v1/docs/page", `${protocol}://${host}`);
+    return NextResponse.redirect(redirectUrl);
   }
 
   // Otherwise return the OpenAPI spec as JSON

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -9,11 +9,9 @@ export async function GET(request: Request) {
 
   // If accessed from a browser, redirect to the UI page
   if (accept.includes("text/html")) {
-    // Construct the redirect URL using headers to handle proxies/load balancers correctly
-    const host =
-      headersList.get("x-forwarded-host") || headersList.get("host") || env.HOST || new URL(request.url).host;
+    // Use trusted HOST environment variable to prevent open redirect vulnerabilities
     const protocol = headersList.get("x-forwarded-proto") || "https";
-    const redirectUrl = new URL("/api/v1/docs/page", `${protocol}://${host}`);
+    const redirectUrl = new URL("/api/v1/docs/page", `${protocol}://${env.HOST}`);
     return NextResponse.redirect(redirectUrl);
   }
 

--- a/src/app/api/v1/docs/route.ts
+++ b/src/app/api/v1/docs/route.ts
@@ -1,3 +1,4 @@
+import env from "@/lib/env";
 import { swaggerSpec } from "@/lib/swagger";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
@@ -9,7 +10,8 @@ export async function GET(request: Request) {
   // If accessed from a browser, redirect to the UI page
   if (accept.includes("text/html")) {
     // Construct the redirect URL using headers to handle proxies/load balancers correctly
-    const host = headersList.get("x-forwarded-host") || headersList.get("host") || request.url;
+    const host =
+      headersList.get("x-forwarded-host") || headersList.get("host") || env.HOST || new URL(request.url).host;
     const protocol = headersList.get("x-forwarded-proto") || "https";
     const redirectUrl = new URL("/api/v1/docs/page", `${protocol}://${host}`);
     return NextResponse.redirect(redirectUrl);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 // });
 const envSchema = z.object({
   DISCORD_WEBHOOK_URL: z.string().url().optional().or(z.literal("")),
+  HOST: z.string().optional(),
 });
 
 const env = envSchema.safeParse(process.env);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 // });
 const envSchema = z.object({
   DISCORD_WEBHOOK_URL: z.string().url().optional().or(z.literal("")),
-  HOST: z.string().optional(),
+  HOST: z.string().min(1),
 });
 
 const env = envSchema.safeParse(process.env);


### PR DESCRIPTION
fix: enhance redirect logic in API documentation route to handle proxies and load balancers correctly

https://czechitas-jira.atlassian.net/browse/CZBANK-84

Problem: if you go to the `https://develop.czechibank.ostrava.digital/api/v1/docs/` , it should redirect you to `https://develop.czechibank.ostrava.digital/api/v1/docs/page` .. but it redirects you to localhost.

This PR should change it, it should check headers and it should work + it should take the env HOST, and it is `HOST=develop.czechibank.ostrava.digital`, so we should be safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HOST environment variable for configurable host settings.

* **Improvements**
  * API documentation endpoint now redirects correctly behind reverse proxies.
  * Added reliable fallback behavior for standard deployments when proxy headers are absent.
  * Deployment will validate that HOST is set, surfacing configuration errors early.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->