### PR TITLE
[CZBANK-82] fix: keep session in sync across tabs

### DIFF
--- a/src/app/profile/page.client.tsx
+++ b/src/app/profile/page.client.tsx
@@ -6,7 +6,8 @@ import { Label } from "@/components/ui/label";
 import { toast } from "@/components/ui/use-toast";
 import { UserAvatar } from "@/components/user/avatar";
 import userServiceClient from "@/domain/user-domain/user-service-client";
-import { authClient, useSession } from "@/lib/auth-client";
+import { authClient } from "@/lib/auth-client";
+import { useSessionWithRefresh } from "@/lib/useSessionWithRefresh";
 import { generateRandomAvatarConfig } from "@/lib/utils";
 import { Apikey } from "@prisma/client";
 import { KeyIcon, SettingsIcon, UserIcon } from "lucide-react";
@@ -21,7 +22,7 @@ export default function ProfileClientPage({
   user: typeof authClient.$Infer.Session.user;
   apiKeys: Omit<Apikey, "key">[];
 }) {
-  const { data: session, isPending, error } = useSession();
+  const { data: session, isPending, error } = useSessionWithRefresh();
   const router = useRouter();
   const [isUpdatingAvatar, setIsUpdatingAvatar] = useState(false);
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -7,6 +7,11 @@ import { Toast, useToast } from "@/components/ui/use-toast";
 import { MIN_PASSWORD_LENGTH } from "@/constants";
 import { LoginSchema, LoginSchemaType, UserBaseSchemaType } from "@/domain/user-domain/user-schema";
 import userServiceClient from "@/domain/user-domain/user-service-client";
+import {
+  broadcastSessionChanged,
+  useRedirectToHomeWhenSignedIn,
+  useSessionWithRefresh,
+} from "@/lib/useSessionWithRefresh";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorContext } from "better-auth/react";
 import Link from "next/link";
@@ -15,6 +20,8 @@ import { useForm } from "react-hook-form";
 
 export default function SignInPage() {
   const { toast } = useToast();
+  const { data: session } = useSessionWithRefresh();
+  useRedirectToHomeWhenSignedIn(session);
 
   const form = useForm<LoginSchemaType>({
     resolver: zodResolver(LoginSchema),
@@ -33,6 +40,7 @@ export default function SignInPage() {
           title: "Success",
           description: "You are signed in",
         } satisfies Toast);
+        broadcastSessionChanged();
         router.push("/");
       },
       onError: (error: ErrorContext) => {

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -15,9 +15,12 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorContext } from "better-auth/react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
+/**
+ * Sign-in page. Renders email/password form; redirects to home when the user already has a session.
+ * On successful sign-in, broadcasts session change (so other tabs refresh) and the redirect hook navigates to `/`.
+ */
 export default function SignInPage() {
   const { toast } = useToast();
   const { data: session } = useSessionWithRefresh();
@@ -31,8 +34,6 @@ export default function SignInPage() {
     } satisfies LoginSchemaType,
   });
 
-  const router = useRouter();
-
   const action: () => void = form.handleSubmit(async (data: UserBaseSchemaType): Promise<void> => {
     await userServiceClient.signIn({ email: data.email, password: data.password } satisfies UserBaseSchemaType, {
       onSuccess: () => {
@@ -41,7 +42,7 @@ export default function SignInPage() {
           description: "You are signed in",
         } satisfies Toast);
         broadcastSessionChanged();
-        router.push("/");
+        // useRedirectToHomeWhenSignedIn will redirect when session refetch completes; avoid double navigation (router.push + hook replace)
       },
       onError: (error: ErrorContext) => {
         form.resetField("password");

--- a/src/components/auth/sign-out.tsx
+++ b/src/components/auth/sign-out.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import userServiceClient from "@/domain/user-domain/user-service-client";
+import { broadcastSessionChanged } from "@/lib/useSessionWithRefresh";
 import { Button } from "../ui/button";
 
+/** Sign-out button. Notifies other tabs via broadcastSessionChanged, then redirects to /signin. */
 export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
   return (
     <Button
@@ -13,8 +15,7 @@ export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
       onClick={async () => {
         await userServiceClient.signOut({
           onSuccess: () => {
-            // Use window.location.replace() to prevent back-button navigation to protected pages
-            // after logout. This is a standard best practice for logout flows.
+            broadcastSessionChanged();
             window.location.replace("/signin");
           },
           onError: (error) => {

--- a/src/components/auth/user-button.tsx
+++ b/src/components/auth/user-button.tsx
@@ -7,17 +7,26 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useSession } from "@/lib/auth-client";
+import { useSessionWithRefresh } from "@/lib/useSessionWithRefresh";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "../ui/button";
 import { UserAvatar } from "../user/avatar";
 import { SignOut } from "./sign-out";
 
+/** Header avatar/menu or Sign in link. Uses last known session during refetch to avoid layout jump; shows Loading only on first load before any session. */
 export default function UserButton() {
-  const { data: session, isPending } = useSession();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
-  if (isPending) return <p className="mt-8 text-center">Loading...</p>;
-  if (!session?.user) return <Link href="/signin">Sign in</Link>;
+  const { data: session, isPending } = useSessionWithRefresh();
+  const lastSessionRef = useRef(session);
+  if (session !== undefined) lastSessionRef.current = session;
+  const displaySession = session ?? lastSessionRef.current;
+
+  if (!mounted) return <Link href="/signin">Sign in</Link>;
+  if (isPending && displaySession === undefined) return <p className="mt-8 text-center">Loading...</p>;
+  if (!displaySession?.user) return <Link href="/signin">Sign in</Link>;
 
   return (
     <DropdownMenu>
@@ -26,14 +35,14 @@ export default function UserButton() {
           className="rounded-full border-2 border-solid border-slate-500 hover:border-slate-200"
           data-testid="avatarCtxMenu"
         >
-          <UserAvatar image={session.user.image ?? null} size={8} />
+          <UserAvatar image={displaySession.user.image ?? null} size={8} />
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col space-y-1">
-            <p className="leading-none">{session.user.name}</p>
-            <p className="text-xs leading-none text-muted-foreground">{session.user.email}</p>
+            <p className="leading-none">{displaySession.user.name}</p>
+            <p className="text-xs leading-none text-muted-foreground">{displaySession.user.email}</p>
           </div>
         </DropdownMenuLabel>
         <DropdownMenuItem asChild>
@@ -41,7 +50,7 @@ export default function UserButton() {
             <Button className="w-full">Profile</Button>
           </Link>
         </DropdownMenuItem>
-        {session.user.role === "admin" ? (
+        {displaySession.user.role === "admin" ? (
           <DropdownMenuItem asChild>
             <Link href="/administration" className="w-full">
               <Button className="w-full">Administration</Button>

--- a/src/components/register/form.tsx
+++ b/src/components/register/form.tsx
@@ -7,6 +7,11 @@ import { ToastAction } from "@/components/ui/toast";
 import { MIN_PASSWORD_LENGTH } from "@/constants";
 import { CreateUserSchemaType, UserSchema } from "@/domain/user-domain/user-schema";
 import userServiceClient from "@/domain/user-domain/user-service-client";
+import {
+  broadcastSessionChanged,
+  useRedirectToHomeWhenSignedIn,
+  useSessionWithRefresh,
+} from "@/lib/useSessionWithRefresh";
 import { generateRandomAvatarConfig } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorContext } from "better-auth/react";
@@ -17,6 +22,9 @@ import { toast, Toast } from "../ui/use-toast";
 
 export function RegisterForm() {
   const router = useRouter();
+  const { data: session } = useSessionWithRefresh();
+  useRedirectToHomeWhenSignedIn(session);
+
   const ExtendedUserSchema = UserSchema.extend({
     confirmPassword: z.string(),
   }).refine((data) => data.password === data.confirmPassword, {
@@ -34,7 +42,6 @@ export function RegisterForm() {
       confirmPassword: "",
     },
   });
-  console.log(form.formState.errors);
 
   const action: () => void = form.handleSubmit(async (data: ExtendedUserSchemaType): Promise<void> => {
     await userServiceClient.signUp(
@@ -47,9 +54,8 @@ export function RegisterForm() {
       {
         onSuccess: () => {
           form.reset();
-          // Refresh router to ensure useSession hook updates after signup
+          broadcastSessionChanged();
           router.refresh();
-          // Navigate to success page
           router.push("/register/success");
         },
         onError: (error: ErrorContext): void => {

--- a/src/components/register/form.tsx
+++ b/src/components/register/form.tsx
@@ -16,14 +16,21 @@ import { generateRandomAvatarConfig } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorContext } from "better-auth/react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { toast, Toast } from "../ui/use-toast";
 
+/**
+ * Registration form (name, email, password, confirm password). Redirects to home when the user already has a session,
+ * except during sign-up so that `router.push("/register/success")` is not overridden. On success, broadcasts session
+ * change and navigates to `/register/success`.
+ */
 export function RegisterForm() {
   const router = useRouter();
+  const [isSigningUp, setIsSigningUp] = useState(false);
   const { data: session } = useSessionWithRefresh();
-  useRedirectToHomeWhenSignedIn(session);
+  useRedirectToHomeWhenSignedIn(session, { skipRedirect: isSigningUp });
 
   const ExtendedUserSchema = UserSchema.extend({
     confirmPassword: z.string(),
@@ -44,6 +51,7 @@ export function RegisterForm() {
   });
 
   const action: () => void = form.handleSubmit(async (data: ExtendedUserSchemaType): Promise<void> => {
+    setIsSigningUp(true);
     await userServiceClient.signUp(
       {
         email: data.email,
@@ -59,6 +67,7 @@ export function RegisterForm() {
           router.push("/register/success");
         },
         onError: (error: ErrorContext): void => {
+          setIsSigningUp(false);
           // Reset password fields if user already exists, because of the security reasons
           form.resetField("password");
           form.resetField("confirmPassword");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,4 +8,8 @@ export const RATE_LIMIT = {
 export const SESSION = {
   EXPIRES_IN: 60 * 30, // 30 minutes
   UPDATE_AGE: 60 * 5, // 5 minutes (every 5 minutes the session expiration is updated)
+  /** BroadcastChannel name for cross-tab session sync (so all tabs show the same user after sign-in/sign-out) */
+  CHANNEL_NAME: "czechibank-session-sync",
+  /** Poll interval in ms for useSessionWithRefresh (keep client session in sync with server across tabs) */
+  POLL_INTERVAL_MS: 10_000,
 };

--- a/src/lib/useSessionWithRefresh.ts
+++ b/src/lib/useSessionWithRefresh.ts
@@ -3,7 +3,7 @@
 import { SESSION } from "@/constants";
 import { useSession as useBetterAuthSession } from "@/lib/auth-client";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Wraps better-auth useSession with cross-tab sync and safe redirects.
@@ -21,14 +21,12 @@ export function useSessionWithRefresh() {
   const refetchRef = useRef<(() => void) | undefined>(undefined);
   if (typeof sessionResult.refetch === "function") refetchRef.current = sessionResult.refetch;
 
-  const triggerRefresh = () => {
+  const triggerRefresh = useCallback(() => {
     refetchRef.current?.();
     router.refresh();
-  };
+  }, [router]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-
     channelRef.current = new BroadcastChannel(SESSION.CHANNEL_NAME);
 
     const handleMessage = (event: MessageEvent) => {
@@ -42,24 +40,22 @@ export function useSessionWithRefresh() {
     return () => {
       channelRef.current?.close();
     };
-  }, [router]);
+  }, [triggerRefresh]);
 
   // Poll periodically so we stay in sync with server (e.g. cookie changed in another tab)
   useEffect(() => {
-    if (typeof window === "undefined") return;
     pollIntervalRef.current = setInterval(triggerRefresh, SESSION.POLL_INTERVAL_MS);
     return () => {
       if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
     };
-  }, [router]);
+  }, [triggerRefresh]);
 
   // Refresh when tab gains focus (user switched back to this tab)
   useEffect(() => {
-    if (typeof window === "undefined") return;
     const onFocus = () => triggerRefresh();
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
-  }, [router]);
+  }, [triggerRefresh]);
 
   // When session user changes to a different user (e.g. another tab signed in as User B), redirect so we never show wrong user
   useEffect(() => {
@@ -82,16 +78,40 @@ export function useSessionWithRefresh() {
   return sessionResult;
 }
 
-/** Redirect to home when user has a session. Use on sign-in and register pages so signed-in users don't see the form. */
-export function useRedirectToHomeWhenSignedIn(session: { user?: unknown } | null | undefined) {
-  useEffect(() => {
-    if (session?.user) {
-      window.location.replace("/");
-    }
-  }, [session?.user]);
+/**
+ * Options for {@link useRedirectToHomeWhenSignedIn}.
+ */
+export interface UseRedirectToHomeWhenSignedInOptions {
+  /** When true, do not redirect (e.g. during sign-up so router.push("/register/success") is not overridden). */
+  skipRedirect?: boolean;
 }
 
-/** Call after sign-in, sign-out, or register so other tabs refetch session and refresh. */
+/**
+ * Redirects to home when the user has a session. Use on sign-in and register pages so signed-in users don't see the form.
+ * Depends on a stable user id so it does not re-run on every session refetch.
+ *
+ * @param session - Session from useSessionWithRefresh (or useSession). Redirect runs when session has a user with an id.
+ * @param options - Optional. Pass `{ skipRedirect: true }` during sign-up so the success redirect is not overridden.
+ */
+export function useRedirectToHomeWhenSignedIn(
+  session: { user?: { id?: string } } | null | undefined,
+  options?: UseRedirectToHomeWhenSignedInOptions,
+) {
+  const userId =
+    session?.user != null && typeof session.user === "object" && "id" in session.user
+      ? (session.user as { id: string }).id
+      : null;
+
+  useEffect(() => {
+    if (options?.skipRedirect || userId == null) return;
+    window.location.replace("/");
+  }, [userId, options?.skipRedirect]);
+}
+
+/**
+ * Notifies other tabs that the session changed. Call after sign-in, sign-out, or register so other tabs refetch
+ * session and refresh (via BroadcastChannel). No-operation when run on the server.
+ */
 export function broadcastSessionChanged() {
   if (typeof window === "undefined") return;
   try {

--- a/src/lib/useSessionWithRefresh.ts
+++ b/src/lib/useSessionWithRefresh.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { SESSION } from "@/constants";
+import { useSession as useBetterAuthSession } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+/**
+ * Wraps better-auth useSession with cross-tab sync and safe redirects.
+ * - Polling and focus: refetches session and calls router.refresh() on an interval and when the tab gains focus so all tabs stay in sync with the server.
+ * - BroadcastChannel: listens for SESSION_CHANGED (sent after sign-in, sign-out, register); other tabs refetch and refresh so they show the same user.
+ * - Redirect to /logged-out when the session user changes to a different user so we never show the wrong user's data.
+ */
+export function useSessionWithRefresh() {
+  const sessionResult = useBetterAuthSession();
+  const router = useRouter();
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastUserIdRef = useRef<string | null>(null);
+  const hasRedirectedToLoggedOutRef = useRef(false);
+  const refetchRef = useRef<(() => void) | undefined>(undefined);
+  if (typeof sessionResult.refetch === "function") refetchRef.current = sessionResult.refetch;
+
+  const triggerRefresh = () => {
+    refetchRef.current?.();
+    router.refresh();
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    channelRef.current = new BroadcastChannel(SESSION.CHANNEL_NAME);
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === "SESSION_CHANGED") {
+        triggerRefresh();
+      }
+    };
+
+    channelRef.current.onmessage = handleMessage;
+
+    return () => {
+      channelRef.current?.close();
+    };
+  }, [router]);
+
+  // Poll periodically so we stay in sync with server (e.g. cookie changed in another tab)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    pollIntervalRef.current = setInterval(triggerRefresh, SESSION.POLL_INTERVAL_MS);
+    return () => {
+      if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+    };
+  }, [router]);
+
+  // Refresh when tab gains focus (user switched back to this tab)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onFocus = () => triggerRefresh();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [router]);
+
+  // When session user changes to a different user (e.g. another tab signed in as User B), redirect so we never show wrong user
+  useEffect(() => {
+    const currentUserId = sessionResult.data?.user?.id ?? null;
+    const previousUserId = lastUserIdRef.current;
+
+    if (
+      previousUserId != null &&
+      currentUserId != null &&
+      previousUserId !== currentUserId &&
+      !hasRedirectedToLoggedOutRef.current
+    ) {
+      hasRedirectedToLoggedOutRef.current = true;
+      window.location.replace("/logged-out");
+    }
+
+    lastUserIdRef.current = currentUserId;
+  }, [sessionResult.data?.user?.id]);
+
+  return sessionResult;
+}
+
+/** Redirect to home when user has a session. Use on sign-in and register pages so signed-in users don't see the form. */
+export function useRedirectToHomeWhenSignedIn(session: { user?: unknown } | null | undefined) {
+  useEffect(() => {
+    if (session?.user) {
+      window.location.replace("/");
+    }
+  }, [session?.user]);
+}
+
+/** Call after sign-in, sign-out, or register so other tabs refetch session and refresh. */
+export function broadcastSessionChanged() {
+  if (typeof window === "undefined") return;
+  try {
+    const channel = new BroadcastChannel(SESSION.CHANNEL_NAME);
+    channel.postMessage({ type: "SESSION_CHANGED", timestamp: Date.now() });
+    channel.close();
+  } catch (_) {}
+}


### PR DESCRIPTION
Session sync: Introduced useSessionWithRefresh, which wraps better-auth’s useSession and:

- Polls the server periodically (configurable interval in SESSION.POLL_INTERVAL_MS).
- Refreshes when the tab gains focus.
- Listens to a BroadcastChannel; when one tab signs in, signs out, or registers, it broadcasts so other tabs refresh immediately.

Redirect when already signed in: If the user has a session and opens /signin or /register, we redirect to / so they don’t see the form and the header stays consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tab session sync with broadcasted session-change notifications.
  * Automatic session refresh on focus and at regular intervals.
  * Safer redirect behavior: auto-redirects signed-in users away from auth pages and prevents redirects during active signup flows.

* **Bug Fixes**
  * Prevents showing another user's data after switching accounts in a different tab.
  * Stabilizes UI during session refetches and avoids double navigation on sign-in/sign-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->