### PR TITLE
CZBANK-121: update seed-users script to clean up

### DIFF
--- a/scripts/seed-users.ts
+++ b/scripts/seed-users.ts
@@ -246,10 +246,16 @@ async function main() {
   console.log("[users seed] Starting seed script...");
   await prisma.$connect();
 
-  // Clean up all data first
-  console.log("[users seed] Cleaning up database...");
-  await prisma.$transaction([prisma.transaction.deleteMany(), prisma.apikey.deleteMany()]);
-  console.log("[users seed] Database cleaned up");
+  // Clean up seed user data only (preserve non-seed users' API keys)
+  const seedEmails = SEED_USERS_LIST.map((u) => u.email.toLowerCase());
+  console.log("[users seed] Cleaning up seed user data...");
+  await prisma.$transaction([
+    prisma.transaction.deleteMany(),
+    prisma.apikey.deleteMany({
+      where: { user: { email: { in: seedEmails } } },
+    }),
+  ]);
+  console.log("[users seed] Seed user data cleaned up");
 
   // Seed users
   await seedUsers();


### PR DESCRIPTION
- Modified the cleanup process in the seed-users script to preserve non-seed users' API keys by filtering based on seed user emails.
- Enhanced logging to reflect the specific cleanup of seed user data.

https://czechitas-jira.atlassian.net/browse/CZBANK-121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data preservation during system initialization to only remove seed-related data, preventing accidental deletion of non-seed user API keys and transaction records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->