### PR TITLE
CZBANK-68 test: stabilize API tests and extend error-handling unit coverage

### DIFF
--- a/tests/api/about.api.test.ts
+++ b/tests/api/about.api.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("About API", () => {
   describe("GET /api/v1/about", () => {
     it("should return 200 with app info", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/about`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/about`);
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.message).toBe("This is the best bank ever!");
@@ -12,7 +13,7 @@ describe("About API", () => {
     });
 
     it("should include version as a string", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/about`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/about`);
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(typeof data.data.version).toBe("string");
@@ -20,7 +21,7 @@ describe("About API", () => {
     });
 
     it("should include date as a valid ISO timestamp", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/about`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/about`);
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(typeof data.data.date).toBe("string");

--- a/tests/api/apikey.api.test.ts
+++ b/tests/api/apikey.api.test.ts
@@ -1,37 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { apiKey, SEED_USERS } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 const BASE = `${config.BASE_URL}/api/v1`;
 
 describe("API Key API", () => {
-  describe("Rate limiting", () => {
-    it("should return 429 when rate limit is exceeded", async () => {
-      const key = apiKey.rateLimited; // rateLimitMax: 2
-
-      // Make requests until we hit 429 (counter may not be at 0 from other test runs)
-      let lastStatus = 0;
-      for (let i = 0; i < 10; i++) {
-        const res = await fetch(`${BASE}/apikey`, {
-          headers: { "X-API-Key": key },
-        });
-        lastStatus = res.status;
-        if (res.status === 429) {
-          const data = await res.json();
-          expect(data.success).toBe(false);
-          expect(data.error.code).toBe("RATE_LIMIT_EXCEEDED");
-          break;
-        }
-        expect(res.status).toBe(200);
-      }
-
-      expect(lastStatus, "Expected 429 after exhausting rate limit").toBe(429);
-    });
-  });
-
   describe("GET /api/v1/apikey", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${BASE}/apikey`);
+      const response = await fetchApi(`${BASE}/apikey`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -39,7 +16,7 @@ describe("API Key API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${BASE}/apikey`, {
+      const response = await fetchApi(`${BASE}/apikey`, {
         headers: { "X-API-Key": "invalid-token" },
       });
       expect(response.status).toBe(401);
@@ -49,7 +26,7 @@ describe("API Key API", () => {
     });
 
     it("should return 200 and API key metadata for authenticated user", async () => {
-      const response = await fetch(`${BASE}/apikey`, {
+      const response = await fetchApi(`${BASE}/apikey`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -60,7 +37,7 @@ describe("API Key API", () => {
     });
 
     it("should return multiple keys for multipleKeys user", async () => {
-      const response = await fetch(`${BASE}/apikey`, {
+      const response = await fetchApi(`${BASE}/apikey`, {
         headers: { "X-API-Key": apiKey.multipleKeys },
       });
       expect(response.status).toBe(200);
@@ -70,7 +47,7 @@ describe("API Key API", () => {
     });
 
     it("should not expose full key values in the response", async () => {
-      const response = await fetch(`${BASE}/apikey`, {
+      const response = await fetchApi(`${BASE}/apikey`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -82,7 +59,7 @@ describe("API Key API", () => {
     });
 
     it("should return 401 for disabled/expired API key", async () => {
-      const response = await fetch(`${BASE}/apikey`, {
+      const response = await fetchApi(`${BASE}/apikey`, {
         headers: { "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key },
       });
       expect(response.status).toBe(401);

--- a/tests/api/bank-account-crud.api.test.ts
+++ b/tests/api/bank-account-crud.api.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { apiKey, SEED_USERS } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("Bank Account CRUD API", () => {
   describe("POST /api/v1/bank-account/create", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ currency: "CZECHITOKEN" }),
@@ -17,7 +18,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 201 and create account with CZECHITOKEN currency", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -34,7 +35,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 201 and create account with custom name", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -49,7 +50,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 422 when body is empty", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -63,7 +64,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 422 when currency is invalid", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -80,13 +81,13 @@ describe("Bank Account CRUD API", () => {
   describe("GET /api/v1/bank-account/[id]", () => {
     it("should return 401 when no API key is provided (with valid CUID)", async () => {
       // GET route validates CUID format first — use a real account ID to pass validation
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       const listData = await listResponse.json();
       const validId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${validId}`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${validId}`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -95,13 +96,13 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 200 and own account details", async () => {
       // First get list to find a valid account ID
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       const listData = await listResponse.json();
       const accountId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       expect(response.status).toBe(200);
@@ -112,7 +113,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 422 for invalid CUID format", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/not-a-cuid`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/not-a-cuid`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       expect(response.status).toBe(422);
@@ -122,14 +123,17 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 404 for another user's account", async () => {
       // Get standardUser's account ID using standardUser's key
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
+      expect(listResponse.status).toBe(200);
       const listData = await listResponse.json();
+      expect(listData.success).toBe(true);
+      expect(listData.data?.bankAccounts?.[0]?.id).toBeDefined();
       const otherAccountId = listData.data.bankAccounts[0].id;
 
       // Try to access it with vojta's key
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       expect(response.status).toBe(404);
@@ -141,7 +145,7 @@ describe("Bank Account CRUD API", () => {
 
   describe("PATCH /api/v1/bank-account/[id]", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "New Name" }),
@@ -154,13 +158,13 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 200 and rename account", async () => {
       // Get vojta's account ID
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       const listData = await listResponse.json();
       const accountId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
@@ -175,14 +179,17 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 404 when renaming another user's account", async () => {
       // Get standardUser's account ID
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
+      expect(listResponse.status).toBe(200);
       const listData = await listResponse.json();
+      expect(listData.success).toBe(true);
+      expect(listData.data?.bankAccounts?.[0]?.id).toBeDefined();
       const otherAccountId = listData.data.bankAccounts[0].id;
 
       // Try to rename it with vojta's key
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
@@ -197,13 +204,13 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 422 for empty name", async () => {
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.vojta },
       });
       const listData = await listResponse.json();
       const accountId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
@@ -219,7 +226,7 @@ describe("Bank Account CRUD API", () => {
 
   describe("DELETE /api/v1/bank-account/[id]", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
         method: "DELETE",
       });
       expect(response.status).toBe(401);
@@ -229,7 +236,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 401 for invalid/incomplete API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
         method: "DELETE",
         headers: { "X-API-Key": "invalid-token" },
       });
@@ -240,7 +247,7 @@ describe("Bank Account CRUD API", () => {
     });
 
     it("should return 401 for disabled/expired API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/some-id`, {
         method: "DELETE",
         headers: { "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key },
       });
@@ -252,7 +259,7 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 409 NON_ZERO_BALANCE when deleting account with balance", async () => {
       // highBalance has 2 accounts and 1M balance — passes min-account check, hits balance check
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.highBalance },
       });
       const listData = await listResponse.json();
@@ -262,7 +269,7 @@ describe("Bank Account CRUD API", () => {
       const accountId =
         listData.data.bankAccounts.find((a: any) => a.balance > 0)?.id ?? listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${accountId}`, {
         method: "DELETE",
         headers: { "X-API-Key": apiKey.highBalance },
       });
@@ -274,7 +281,7 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 200 when deleting zero-balance account (not the last one)", async () => {
       // Create a fresh account so the test is self-contained and repeatable
-      const createResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account/create`, {
+      const createResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -287,7 +294,7 @@ describe("Bank Account CRUD API", () => {
       const newAccountId = createData.data.bankAccount.id;
 
       // Delete the newly created account (0 balance, not the last one)
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${newAccountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${newAccountId}`, {
         method: "DELETE",
         headers: { "X-API-Key": apiKey.zeroBalance },
       });
@@ -298,13 +305,16 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 400 when deleting last active account", async () => {
       // standardUser has exactly 1 account — no dependency on prior tests
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
+      expect(listResponse.status).toBe(200);
       const listData = await listResponse.json();
+      expect(listData.success).toBe(true);
+      expect(listData.data?.bankAccounts?.[0]?.id).toBeDefined();
       const lastAccountId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${lastAccountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${lastAccountId}`, {
         method: "DELETE",
         headers: { "X-API-Key": apiKey.standardUser },
       });
@@ -316,13 +326,16 @@ describe("Bank Account CRUD API", () => {
 
     it("should return 404 when deleting another user's account", async () => {
       // Get standardUser's account, try to delete with vojta's key
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
+      expect(listResponse.status).toBe(200);
       const listData = await listResponse.json();
+      expect(listData.success).toBe(true);
+      expect(listData.data?.bankAccounts?.[0]?.id).toBeDefined();
       const otherAccountId = listData.data.bankAccounts[0].id;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/${otherAccountId}`, {
         method: "DELETE",
         headers: { "X-API-Key": apiKey.vojta },
       });

--- a/tests/api/bank-account-get-all.api.test.ts
+++ b/tests/api/bank-account-get-all.api.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { apiKey, SEED_USERS } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("Bank Account Get All API", () => {
   describe("GET /api/v1/bank-account/get-all", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -13,7 +14,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
         headers: { "X-API-Key": "invalid-token" },
       });
       expect(response.status).toBe(401);
@@ -23,7 +24,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should return 401 for disabled/expired API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
         headers: { "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key },
       });
       expect(response.status).toBe(401);
@@ -33,7 +34,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should return 200 and paginated list of all bank accounts", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -45,7 +46,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should respect page and limit parameters", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all?page=1&limit=2`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all?page=1&limit=2`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -57,7 +58,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should return 422 for invalid pagination parameters", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all?page=0&limit=0`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all?page=0&limit=0`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(422);
@@ -66,7 +67,7 @@ describe("Bank Account Get All API", () => {
     });
 
     it("should return empty array for page beyond total", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account/get-all?page=999`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account/get-all?page=999`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);

--- a/tests/api/bank-account.api.test.ts
+++ b/tests/api/bank-account.api.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, test } from "vitest";
 import { apiKey } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 test.skip("should create a bank account", async () => {
-  const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+  const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -20,7 +21,7 @@ test.skip("should create a bank account", async () => {
 describe("Bank Account API", () => {
   describe("GET /api/v1/bank-account", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`);
       expect(response.status).toBe(401);
       const data = await response.json();
 
@@ -29,7 +30,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: {
           "X-API-Key": "invalid-token",
         },
@@ -42,7 +43,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return bank accounts with valid API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: {
           "X-API-Key": apiKey.standardUser,
         },
@@ -56,7 +57,7 @@ describe("Bank Account API", () => {
     });
 
     it("should handle pagination parameters", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account?page=1&limit=5`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account?page=1&limit=5`, {
         headers: {
           "X-API-Key": apiKey.highBalance,
         },
@@ -69,7 +70,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return 422 for invalid pagination parameters", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account?page=0&limit=0`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account?page=0&limit=0`, {
         headers: {
           "X-API-Key": apiKey.highBalance,
         },
@@ -84,7 +85,7 @@ describe("Bank Account API", () => {
 
   describe("Method Not Allowed (405)", () => {
     it("should return 405 for POST /api/v1/bank-account", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -96,7 +97,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return 405 for DELETE /api/v1/bank-account", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         method: "DELETE",
         headers: { "X-API-Key": apiKey.standardUser },
       });
@@ -104,7 +105,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return 405 for PUT /api/v1/bank-account", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -116,7 +117,7 @@ describe("Bank Account API", () => {
     });
 
     it("should return 405 for PATCH /api/v1/bank-account", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",

--- a/tests/api/features.api.test.ts
+++ b/tests/api/features.api.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { apiKey } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("Features API", () => {
   // Store original features state for cleanup
@@ -9,7 +10,7 @@ describe("Features API", () => {
   afterAll(async () => {
     // Restore original feature state if we modified it
     if (originalFeatures) {
-      await fetch(`${config.BASE_URL}/api/v1/features/update`, {
+      await fetchApi(`${config.BASE_URL}/api/v1/features/update`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -22,7 +23,7 @@ describe("Features API", () => {
 
   describe("GET /api/v1/features/get-all", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -30,7 +31,7 @@ describe("Features API", () => {
     });
 
     it("should return 200 and list of features", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -41,8 +42,8 @@ describe("Features API", () => {
     });
 
     it("should return features with expected fields", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
+        headers: { "X-API-Key": apiKey.vojta },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -55,8 +56,8 @@ describe("Features API", () => {
     });
 
     it("should contain SEND_MONEY_WITHOUT_ACCOUNT_BALANCE feature key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
+        headers: { "X-API-Key": apiKey.highBalance },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -65,8 +66,8 @@ describe("Features API", () => {
     });
 
     it("should return pagination meta in response", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
+        headers: { "X-API-Key": apiKey.multipleKeys },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -79,8 +80,8 @@ describe("Features API", () => {
     });
 
     it("should respect page and limit query parameters", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=2`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=2`, {
+        headers: { "X-API-Key": apiKey.appAdmin },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -91,23 +92,23 @@ describe("Features API", () => {
 
     it("should return correct totalPages based on limit", async () => {
       // First get total count with a large limit
-      const allResponse = await fetch(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=100`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const allResponse = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=100`, {
+        headers: { "X-API-Key": apiKey.vojta },
       });
       const allData = await allResponse.json();
       const total = allData.meta.pagination.total;
 
       // Now request with limit=2 and verify totalPages
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=2`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?page=1&limit=2`, {
+        headers: { "X-API-Key": apiKey.multipleKeys },
       });
       const data = await response.json();
       expect(data.meta.pagination.totalPages).toBe(Math.ceil(total / 2));
     });
 
     it("should use default page=1 and limit=10 when not provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
+        headers: { "X-API-Key": apiKey.highBalance },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -116,7 +117,7 @@ describe("Features API", () => {
     });
 
     it("should return 422 for page < 1", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?page=-1`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?page=-1`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(422);
@@ -125,8 +126,8 @@ describe("Features API", () => {
     });
 
     it("should return 422 for limit < 1", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?limit=0`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?limit=0`, {
+        headers: { "X-API-Key": apiKey.vojta },
       });
       expect(response.status).toBe(422);
       const data = await response.json();
@@ -134,8 +135,8 @@ describe("Features API", () => {
     });
 
     it("should return 422 for limit > 100", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?limit=101`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?limit=101`, {
+        headers: { "X-API-Key": apiKey.multipleKeys },
       });
       expect(response.status).toBe(422);
       const data = await response.json();
@@ -143,15 +144,15 @@ describe("Features API", () => {
     });
 
     it("should accept limit=100 (boundary)", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?limit=100`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?limit=100`, {
+        headers: { "X-API-Key": apiKey.appAdmin },
       });
       expect(response.status).toBe(200);
     });
 
     it("should accept limit=1 (boundary)", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/get-all?limit=1`, {
-        headers: { "X-API-Key": apiKey.standardUser },
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all?limit=1`, {
+        headers: { "X-API-Key": apiKey.zeroBalance },
       });
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -162,7 +163,7 @@ describe("Features API", () => {
 
   describe("POST /api/v1/features/update", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/update`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/update`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ features: [] }),
@@ -175,7 +176,7 @@ describe("Features API", () => {
 
     it("should return 200 and update a feature toggle", async () => {
       // First, get all features to save original state
-      const getResponse = await fetch(`${config.BASE_URL}/api/v1/features/get-all`, {
+      const getResponse = await fetchApi(`${config.BASE_URL}/api/v1/features/get-all`, {
         headers: { "X-API-Key": apiKey.appAdmin },
       });
       const getData = await getResponse.json();
@@ -185,7 +186,7 @@ describe("Features API", () => {
       const featureToToggle = { ...getData.data.features[0] };
       featureToToggle.toggle = !featureToToggle.toggle;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/update`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/update`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -199,7 +200,7 @@ describe("Features API", () => {
     });
 
     it("should return 403 when user is not admin", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/update`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/update`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -214,7 +215,7 @@ describe("Features API", () => {
     });
 
     it("should return 422 for empty body", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/features/update`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/features/update`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/tests/api/helpers/fetch-api.ts
+++ b/tests/api/helpers/fetch-api.ts
@@ -1,0 +1,65 @@
+/**
+ * HTTP helpers used by `tests/api/**`.
+ *
+ * `fetchApi()` is the default helper for integration tests that talk to a running server.
+ * When the server responds with `429 Too Many Requests`, the helper can wait for the
+ * rate-limit window to reset and then retry the request once.
+ *
+ * `fetchWithoutRateLimitRetry()` keeps the raw behavior and is used by tests that need
+ * to assert on the original `429` response directly.
+ *
+ * These environment variables affect only the test runner:
+ * | Variable | Effect |
+ * |----------|--------|
+ * | `API_TEST_NO_429_RETRY=1` | Disables the cooldown retry |
+ * | `API_TEST_429_MAX_RETRIES` | Number of retries after a `429` (default `1`) |
+ * | `API_TEST_429_COOLDOWN_MS` | Wait time before retry (default `65000`) |
+ */
+
+const RATE_LIMIT_COOLDOWN_MS = Number(process.env.API_TEST_429_COOLDOWN_MS ?? "65000");
+const MAX_429_RETRIES = Number(process.env.API_TEST_429_MAX_RETRIES ?? "1");
+
+function shouldRetryOn429(): boolean {
+  return process.env.API_TEST_NO_429_RETRY !== "1" && MAX_429_RETRIES > 0;
+}
+
+function shortUrl(input: string | URL): string {
+  const s = typeof input === "string" ? input : input.toString();
+  return s.length > 80 ? `${s.slice(0, 77)}…` : s;
+}
+
+/**
+ * Default HTTP helper for API integration tests.
+ *
+ * Returns the original response immediately for non-`429` statuses.
+ * For `429`, logs the wait, sleeps for the configured cooldown, and retries.
+ */
+export async function fetchApi(input: string | URL, init?: RequestInit): Promise<Response> {
+  let response = await fetch(input, init);
+  if (response.status !== 429 || !shouldRetryOn429()) {
+    return response;
+  }
+  const cooldownSec = Math.round(RATE_LIMIT_COOLDOWN_MS / 1000);
+  console.warn(
+    `[api tests][429 retry] Got 429 from ${shortUrl(input)}. Waiting ${cooldownSec}s for rate-limit window, then retrying (up to ${MAX_429_RETRIES} time(s)). Set API_TEST_NO_429_RETRY=1 to skip wait.`,
+  );
+  for (let attempt = 0; attempt < MAX_429_RETRIES; attempt++) {
+    await new Promise((r) => setTimeout(r, RATE_LIMIT_COOLDOWN_MS));
+    response = await fetch(input, init);
+    if (response.status !== 429) {
+      console.warn(`[api tests][429 retry] Retry succeeded (${response.status}) for ${shortUrl(input)}`);
+      return response;
+    }
+  }
+  console.warn(`[api tests][429 retry] Still 429 after cooldown for ${shortUrl(input)}`);
+  return response;
+}
+
+/**
+ * Raw `fetch` without the `429` cooldown retry.
+ *
+ * Use this in tests that intentionally verify rate-limiting behavior.
+ */
+export async function fetchWithoutRateLimitRetry(input: string | URL, init?: RequestInit): Promise<Response> {
+  return fetch(input, init);
+}

--- a/tests/api/transactions.api.test.ts
+++ b/tests/api/transactions.api.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { apiKey, SEED_USERS } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("Transactions API", () => {
   describe("GET /api/v1/transactions", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -13,7 +14,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
         headers: {
           "X-API-Key": "invalid-token",
         },
@@ -25,7 +26,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 401 for disabled/expired API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
         headers: {
           "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key,
         },
@@ -37,7 +38,7 @@ describe("Transactions API", () => {
     });
 
     it("should return transactions with valid API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
         headers: {
           "X-API-Key": apiKey.vojta,
         },
@@ -51,7 +52,7 @@ describe("Transactions API", () => {
 
     describe("Pagination", () => {
       it("should return first page with default limit (10)", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
           headers: {
             "X-API-Key": apiKey.highBalance,
           },
@@ -69,7 +70,7 @@ describe("Transactions API", () => {
       });
 
       it("should return second page with 10 items", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions?page=2`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions?page=2`, {
           headers: {
             "X-API-Key": apiKey.highBalance,
           },
@@ -87,7 +88,7 @@ describe("Transactions API", () => {
       });
 
       it("should return 422 for invalid pagination parameters", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions?page=0&limit=0`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions?page=0&limit=0`, {
           headers: {
             "X-API-Key": apiKey.highBalance,
           },
@@ -99,7 +100,7 @@ describe("Transactions API", () => {
       });
 
       it("should return empty array for page beyond total pages", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions?page=921`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions?page=921`, {
           headers: {
             "X-API-Key": apiKey.vojta,
           },
@@ -119,7 +120,7 @@ describe("Transactions API", () => {
 
     describe("Sorting", () => {
       it("should sort by createdAt in descending order by default", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
           headers: {
             "X-API-Key": apiKey.highBalance,
           },
@@ -134,7 +135,7 @@ describe("Transactions API", () => {
       });
 
       it("should sort by amount in ascending order", async () => {
-        const response = await fetch(`${config.BASE_URL}/api/v1/transactions?sortBy=amount&sortOrder=asc`, {
+        const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions?sortBy=amount&sortOrder=asc`, {
           headers: {
             "X-API-Key": apiKey.highBalance,
           },
@@ -150,7 +151,7 @@ describe("Transactions API", () => {
 
   describe("GET /api/v1/transactions/[id]", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/123`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/123`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -158,7 +159,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 401 for disabled/expired API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/some-id`, {
         headers: {
           "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key,
         },
@@ -170,7 +171,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/some-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/some-id`, {
         headers: {
           "X-API-Key": "invalid-token",
         },
@@ -182,7 +183,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 404 for non-existent transaction", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/non-existent-id`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/non-existent-id`, {
         headers: {
           "X-API-Key": apiKey.highBalance,
         },
@@ -195,7 +196,7 @@ describe("Transactions API", () => {
 
     it("should return transaction details for valid ID", async () => {
       // First get a list of transactions to get a valid ID
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/transactions`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/transactions`, {
         headers: {
           "X-API-Key": apiKey.highBalance,
         },
@@ -204,7 +205,7 @@ describe("Transactions API", () => {
       const transactionId = listData.data.transactions[0].id;
 
       // Then get the details for that transaction
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/${transactionId}`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/${transactionId}`, {
         headers: {
           "X-API-Key": apiKey.highBalance,
         },
@@ -219,7 +220,7 @@ describe("Transactions API", () => {
   describe("POST /api/v1/transactions/create", () => {
     it("should return 201 for valid request", async () => {
       const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -237,7 +238,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -254,11 +255,11 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for missing required fields", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({}),
       });
@@ -270,7 +271,7 @@ describe("Transactions API", () => {
 
     it("should return 422 for invalid amount", async () => {
       const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -295,7 +296,7 @@ describe("Transactions API", () => {
 
     it("should return 404 for non-existent recipient bank account", async () => {
       const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -316,7 +317,7 @@ describe("Transactions API", () => {
 
     it("should return 422 for amount greater than Number.MAX_SAFE_INTEGER", async () => {
       const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -340,7 +341,7 @@ describe("Transactions API", () => {
     it("should return 409 INSUFFICIENT_BALANCE when sender has no funds", async () => {
       // Look up zeroBalance's active account dynamically (seed account may have
       // been soft-deleted by a prior test run)
-      const listResponse = await fetch(`${config.BASE_URL}/api/v1/bank-account`, {
+      const listResponse = await fetchApi(`${config.BASE_URL}/api/v1/bank-account`, {
         headers: { "X-API-Key": apiKey.zeroBalance },
       });
       const listData = await listResponse.json();
@@ -348,7 +349,7 @@ describe("Transactions API", () => {
       expect(listData.data.bankAccounts.length).toBeGreaterThan(0);
       const fromNumber = listData.data.bankAccounts[0].number;
 
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -367,7 +368,7 @@ describe("Transactions API", () => {
     });
 
     it("should return 403 FORBIDDEN when sending from another user's account", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -386,17 +387,17 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for toBankNumber not ending with /5555", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
           toBankNumber: "123456789012/1234",
-          fromBankNumber: hb.bankAccounts[0].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -405,17 +406,17 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for toBankNumber with wrong length", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
           toBankNumber: "12345/5555",
-          fromBankNumber: hb.bankAccounts[0].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -424,15 +425,16 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for fromBankNumber not ending with /5555", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
-          toBankNumber: SEED_USERS.vojta.bankAccounts[0].number,
+          toBankNumber: v.bankAccounts[1].number,
           fromBankNumber: "123456789012/1234",
         }),
       });
@@ -442,17 +444,17 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for amount of 0", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 0,
-          toBankNumber: SEED_USERS.vojta.bankAccounts[0].number,
-          fromBankNumber: hb.bankAccounts[0].number,
+          toBankNumber: v.bankAccounts[2].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -461,17 +463,17 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 when amount is a string", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const su = SEED_USERS.standardUser;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.standardUser,
         },
         body: JSON.stringify({
           amount: "one hundred",
-          toBankNumber: hb.bankAccounts[1].number,
-          fromBankNumber: hb.bankAccounts[0].number,
+          toBankNumber: SEED_USERS.vojta.bankAccounts[0].number,
+          fromBankNumber: su.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -481,7 +483,7 @@ describe("Transactions API", () => {
 
     it("should round amount to 1 decimal place", async () => {
       const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -501,16 +503,16 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 when toBankNumber field is missing", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
-          fromBankNumber: hb.bankAccounts[0].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -519,15 +521,16 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 when fromBankNumber field is missing", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
-          toBankNumber: SEED_USERS.vojta.bankAccounts[0].number,
+          toBankNumber: v.bankAccounts[1].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -536,16 +539,16 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 when amount field is missing", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
-          toBankNumber: hb.bankAccounts[1].number,
-          fromBankNumber: hb.bankAccounts[0].number,
+          toBankNumber: v.bankAccounts[1].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);
@@ -554,17 +557,17 @@ describe("Transactions API", () => {
     });
 
     it("should return 422 for toBankNumber that is too long", async () => {
-      const hb = SEED_USERS.highBalance;
-      const response = await fetch(`${config.BASE_URL}/api/v1/transactions/create`, {
+      const v = SEED_USERS.vojta;
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/transactions/create`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-Key": apiKey.highBalance,
+          "X-API-Key": apiKey.vojta,
         },
         body: JSON.stringify({
           amount: 1,
           toBankNumber: "1234567890123456/5555",
-          fromBankNumber: hb.bankAccounts[0].number,
+          fromBankNumber: v.bankAccounts[0].number,
         }),
       });
       expect(response.status).toBe(422);

--- a/tests/api/user.api.test.ts
+++ b/tests/api/user.api.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { apiKey, SEED_USERS } from "../../shared/fixtures";
 import { config } from "./config/config";
+import { fetchApi } from "./helpers/fetch-api";
 
 describe("User API", () => {
   describe("GET /api/v1/user", () => {
     it("should return 401 when no API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user`);
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user`);
       expect(response.status).toBe(401);
       const data = await response.json();
       expect(data.success).toBe(false);
@@ -13,7 +14,7 @@ describe("User API", () => {
     });
 
     it("should return 401 when invalid API key is provided", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user`, {
         headers: { "X-API-Key": "invalid-token" },
       });
       expect(response.status).toBe(401);
@@ -23,7 +24,7 @@ describe("User API", () => {
     });
 
     it("should return 200 and user profile for valid API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user`, {
         headers: { "X-API-Key": apiKey.standardUser },
       });
       expect(response.status).toBe(200);
@@ -34,7 +35,7 @@ describe("User API", () => {
     });
 
     it("should return 401 for disabled API key", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user`, {
         headers: { "X-API-Key": SEED_USERS.expiredKey.apiKeys[0].key },
       });
       expect(response.status).toBe(401);
@@ -46,7 +47,7 @@ describe("User API", () => {
 
   describe("POST /api/v1/user/create", () => {
     it("should return 201 and create a new user", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -63,7 +64,7 @@ describe("User API", () => {
     });
 
     it("should return 422 for short password", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -79,7 +80,7 @@ describe("User API", () => {
     });
 
     it("should return 422 for missing name", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -93,7 +94,7 @@ describe("User API", () => {
     });
 
     it("should return 422 for missing email", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -107,7 +108,7 @@ describe("User API", () => {
     });
 
     it("should return 422 for missing password", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -121,7 +122,7 @@ describe("User API", () => {
     });
 
     it("should return 422 for invalid email format", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -136,7 +137,7 @@ describe("User API", () => {
     });
 
     it("should return 409 for duplicate email", async () => {
-      const response = await fetch(`${config.BASE_URL}/api/v1/user/create`, {
+      const response = await fetchApi(`${config.BASE_URL}/api/v1/user/create`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/tests/api/zzz-rate-limits.api.test.ts
+++ b/tests/api/zzz-rate-limits.api.test.ts
@@ -1,0 +1,93 @@
+/**
+ * End-of-suite checks for HTTP `429` / `RATE_LIMIT_EXCEEDED`.
+ *
+ * This file runs late in the API suite so the rate-limit assertions do not consume
+ * request budget needed by the rest of the tests.
+ *
+ * Included checks:
+ * 1. Per-key limit on `GET /apikey` using the seeded `rate.limited@example.com` user.
+ * 2. Global auth limit on `GET /user`, enabled only when the target host is expected
+ *    to enforce a tight server-wide limit.
+ *
+ * The global test is controlled by `API_TEST_EXPECT_GLOBAL_RATE_LIMIT`:
+ * - unset / not `"1"`: skip the global test
+ * - `"1"`: run the global test
+ *
+ * A `console.warn` is printed when the global test is disabled so the terminal output
+ * explains why the suite contains a skipped test.
+ */
+
+import { describe, expect, it, type TestContext } from "vitest";
+import { apiKey } from "../../shared/fixtures";
+import { config } from "./config/config";
+import { fetchWithoutRateLimitRetry } from "./helpers/fetch-api";
+
+const BASE = `${config.BASE_URL}/api/v1`;
+
+// Print an explicit log message because Vitest often shows only "N skipped" in summaries.
+if (process.env.API_TEST_EXPECT_GLOBAL_RATE_LIMIT !== "1") {
+  console.warn(
+    "[api tests][skip] Global rate-limit test not run. Set API_TEST_EXPECT_GLOBAL_RATE_LIMIT=1 against a host with tight limits (e.g. ENV=PROD). CI uses ENV=CI (high limit), so this stays off by default.",
+  );
+}
+
+describe("Rate limits (end of suite — may exhaust request budgets)", () => {
+  describe("Per-key GET /apikey (fixture rateLimitMax: 2)", () => {
+    it("returns 429 after key-specific limit", async (ctx: TestContext) => {
+      const key = apiKey.rateLimited;
+
+      let lastStatus = 0;
+      for (let i = 0; i < 12; i++) {
+        const res = await fetchWithoutRateLimitRetry(`${BASE}/apikey`, {
+          headers: { "X-API-Key": key },
+        });
+        lastStatus = res.status;
+        if (i === 0 && res.status === 401) {
+          const reason =
+            "Per-key rate-limit test skipped: fixture API key unknown on this server (401). Seed DB with pnpm db:seed:users so user rate.limited@example.com and key exist.";
+          console.warn(`[api tests][skip] ${reason}`);
+          ctx.skip(reason);
+          return;
+        }
+        if (res.status === 429) {
+          const data = await res.json();
+          expect(data.success).toBe(false);
+          expect(data.error.code).toBe("RATE_LIMIT_EXCEEDED");
+          break;
+        }
+        expect(res.status).toBe(200);
+      }
+
+      expect(lastStatus, "Expected 429 — ensure seed user rate.limited exists (pnpm db:seed:users)").toBe(429);
+    });
+  });
+
+  describe.skipIf(process.env.API_TEST_EXPECT_GLOBAL_RATE_LIMIT !== "1")(
+    "Global limit (opt-in, PROD-tight hosts)",
+    () => {
+      it("returns 429 after global auth window", async () => {
+        const key = apiKey.appAdmin;
+        let saw429 = false;
+
+        for (let i = 0; i < 45; i++) {
+          const res = await fetchWithoutRateLimitRetry(`${BASE}/user`, {
+            headers: { "X-API-Key": key },
+          });
+          if (res.status === 429) {
+            saw429 = true;
+            const data = await res.json();
+            expect(data.success).toBe(false);
+            expect(data.error.code).toBe("RATE_LIMIT_EXCEEDED");
+            break;
+          }
+          expect(res.status).toBe(200);
+        }
+
+        expect(
+          saw429,
+          "Set API_TEST_EXPECT_GLOBAL_RATE_LIMIT=1 only when testing a host with tight global limits (e.g. ENV=PROD).",
+        ).toBe(true);
+      });
+    },
+  );
+});

--- a/tests/unit/api-error-status-map.test.ts
+++ b/tests/unit/api-error-status-map.test.ts
@@ -30,6 +30,21 @@ describe("apiErrorStatusMap", () => {
   it("should map INTERNAL_ERROR to 500", () => {
     expect(apiErrorStatusMap[ApiErrorCode.INTERNAL_ERROR]).toBe(500);
   });
+
+  it("should map CONFLICT and INSUFFICIENT_BALANCE to 409", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.CONFLICT]).toBe(409);
+    expect(apiErrorStatusMap[ApiErrorCode.INSUFFICIENT_BALANCE]).toBe(409);
+    expect(apiErrorStatusMap[ApiErrorCode.NON_ZERO_BALANCE]).toBe(409);
+  });
+
+  it("should map OPERATION_FAILED and INVALID_PASSWORD to 400", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.OPERATION_FAILED]).toBe(400);
+    expect(apiErrorStatusMap[ApiErrorCode.INVALID_PASSWORD]).toBe(400);
+  });
+
+  it("should map BAD_GATEWAY to 502", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.BAD_GATEWAY]).toBe(502);
+  });
 });
 
 describe("mapErrorCodeToStatus", () => {

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -164,6 +164,50 @@ describe("fromUnknown", () => {
     });
   });
 
+  describe("additional better-auth code mappings (body.code)", () => {
+    it("should map INVALID_TOKEN to UNAUTHORIZED", () => {
+      const error = Object.assign(new Error("Bad token"), {
+        body: { code: "INVALID_TOKEN", message: "Bad token" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.UNAUTHORIZED);
+    });
+
+    it("should map SESSION_NOT_FRESH to UNAUTHORIZED", () => {
+      const error = Object.assign(new Error("Stale session"), {
+        body: { code: "SESSION_NOT_FRESH", message: "Stale session" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.UNAUTHORIZED);
+    });
+
+    it("should map INVALID_PASSWORD to INVALID_PASSWORD", () => {
+      const error = Object.assign(new Error("Wrong password"), {
+        body: { code: "INVALID_PASSWORD", message: "Wrong password" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.INVALID_PASSWORD);
+    });
+
+    it("should map TOO_MANY_ATTEMPTS to RATE_LIMIT_EXCEEDED", () => {
+      const error = Object.assign(new Error("Too many tries"), {
+        body: { code: "TOO_MANY_ATTEMPTS", message: "Too many tries" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.RATE_LIMIT_EXCEEDED);
+    });
+
+    it("should map PROVIDER_NOT_FOUND to NOT_FOUND", () => {
+      const error = Object.assign(new Error("No provider"), {
+        body: { code: "PROVIDER_NOT_FOUND", message: "No provider" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.NOT_FOUND);
+    });
+
+    it("should map VALIDATION_ERROR in body to VALIDATION_ERROR", () => {
+      const error = Object.assign(new Error("Invalid"), {
+        body: { code: "VALIDATION_ERROR", message: "Invalid" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.VALIDATION_ERROR);
+    });
+  });
+
   describe("non-object errors", () => {
     it("should use fallback message for string errors", () => {
       const result = fromUnknown("oops");

--- a/tests/unit/result-helpers.test.ts
+++ b/tests/unit/result-helpers.test.ts
@@ -1,0 +1,103 @@
+import { ApiErrorCode } from "@/lib/response";
+import { toApiResponse, toPaginatedApiResponse, toServiceResponse } from "@/lib/result-helpers";
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it } from "vitest";
+
+describe("toApiResponse", () => {
+  it("returns success status and envelope for ok ResultAsync", async () => {
+    const res = await toApiResponse(okAsync({ id: "a" }), "Created", 201);
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.message).toBe("Created");
+    expect(json.data).toEqual({ id: "a" });
+    expect(json.meta?.timestamp).toBeDefined();
+  });
+
+  it("returns HTTP status from mapErrorCodeToStatus for Err", async () => {
+    const res = await toApiResponse(
+      errAsync({ code: ApiErrorCode.EMAIL_ALREADY_EXISTS, message: "User exists" }),
+      "ignored",
+      200,
+    );
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.message).toBe("User exists");
+    expect(json.error.code).toBe(ApiErrorCode.EMAIL_ALREADY_EXISTS);
+    expect(json.error.message).toBe("User exists");
+    expect(json.meta?.timestamp).toBeDefined();
+  });
+
+  it("maps RATE_LIMIT_EXCEEDED to 429", async () => {
+    const res = await toApiResponse(errAsync({ code: ApiErrorCode.RATE_LIMIT_EXCEEDED, message: "Slow down" }), "ok");
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error.code).toBe(ApiErrorCode.RATE_LIMIT_EXCEEDED);
+  });
+
+  it("includes validation details when present on AppError", async () => {
+    const res = await toApiResponse(
+      errAsync({
+        code: ApiErrorCode.VALIDATION_ERROR,
+        message: "Validation error",
+        details: [{ code: ApiErrorCode.VALIDATION_ERROR, field: "email", message: "Invalid" }],
+      }),
+      "ok",
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.details).toHaveLength(1);
+    expect(json.error.details[0].field).toBe("email");
+  });
+});
+
+describe("toPaginatedApiResponse", () => {
+  it("puts pagination on success meta and returns 200", async () => {
+    const pagination = { page: 1, limit: 10, total: 2, totalPages: 1 };
+    const res = await toPaginatedApiResponse(okAsync({ rows: [1, 2] }), "Listed", () => ({
+      body: { rows: [1, 2] },
+      pagination,
+    }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual({ rows: [1, 2] });
+    expect(json.meta.pagination).toEqual(pagination);
+  });
+
+  it("uses same error status mapping as toApiResponse on Err", async () => {
+    const res = await toPaginatedApiResponse(
+      errAsync({ code: ApiErrorCode.NOT_FOUND, message: "Missing" }),
+      "Listed",
+      () => ({ body: {}, pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
+    );
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe(ApiErrorCode.NOT_FOUND);
+  });
+});
+
+describe("toServiceResponse", () => {
+  it("returns SuccessResponse shape for ok", async () => {
+    const out = await toServiceResponse(okAsync({ x: 1 }), "Done");
+    expect(out.success).toBe(true);
+    if (out.success) {
+      expect(out.data).toEqual({ x: 1 });
+      expect(out.message).toBe("Done");
+    }
+  });
+
+  it("returns ErrorResponse shape for err", async () => {
+    const out = await toServiceResponse(errAsync({ code: ApiErrorCode.UNAUTHORIZED, message: "Nope" }), "Done");
+    expect(out.success).toBe(false);
+    if (!out.success) {
+      expect(out.error.code).toBe(ApiErrorCode.UNAUTHORIZED);
+      expect(out.error.message).toBe("Nope");
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,22 @@
 import path from "path";
 import { defineConfig } from "vitest/config";
 
+/**
+ * Unit + API integration tests. API tests hit a live server (`tests/api/config/config.ts` → HOST).
+ * See `tests/api/helpers/fetch-api.ts` and `tests/api/zzz-rate-limits.api.test.ts` for rate-limit handling.
+ */
 export default defineConfig({
   test: {
     environment: "node",
     globals: true,
     include: ["./tests/api/**/*.test.ts", "./tests/unit/**/*.test.ts"],
+    /**
+     * Run one test file at a time. Reduces parallel traffic against the same API keys / rate-limit buckets
+     * (Better Auth + `src/server-constants.ts`). Also makes `tests/api/zzz-*.test.ts` run after other API files alphabetically.
+     */
+    fileParallelism: false,
+    /** Must exceed `API_TEST_429_COOLDOWN_MS` (default 65s) when `tests/api/helpers/fetch-api.ts` retries on 429. */
+    testTimeout: 120_000,
     // projects: [ "./tests/api/**/*.test.ts", "./tests/unit/**/*.test.ts"],
   },
   resolve: {


### PR DESCRIPTION
Commit 1 — test: stabilize API integration tests around rate limits

- Adds tests/api/helpers/fetch-api.ts with a shared API fetch helper, including optional retry behavior for 429 responses and a raw variant for tests that must assert on 429.
- Updates Vitest config so API test files run sequentially and have enough timeout for rate-limit cooldown retries.
- Adds tests/api/zzz-rate-limits.api.test.ts for explicit rate-limit checks. The global limit scenario stays opt-in via API_TEST_EXPECT_GLOBAL_RATE_LIMIT=1.
- Updates existing API tests to use the shared helper and improves a few assertions so failures are clearer and less flaky.

Commit 2 — test: add unit coverage for error pipeline (result helpers, mappings)

- Adds tests/unit/result-helpers.test.ts for toApiResponse, toPaginatedApiResponse, and toServiceResponse.
- Extends tests/unit/errors.test.ts with more fromUnknown cases for better-auth style error codes.
- Extends tests/unit/api-error-status-map.test.ts with coverage for the remaining status mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added HTTP request helper for API testing with automatic rate-limit retry logic.
  * Expanded test coverage for error code mappings and response formatting.
  * Added dedicated rate-limit validation tests.
  * Refactored API tests to use standardized request helper across all suites.

* **Chores**
  * Configured sequential test file execution and increased test timeout duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->