### PR TITLE
test: add unit coverage for CZBANK-68 error pipeline

### DIFF
--- a/tests/unit/api-error-status-map.test.ts
+++ b/tests/unit/api-error-status-map.test.ts
@@ -30,6 +30,21 @@ describe("apiErrorStatusMap", () => {
   it("should map INTERNAL_ERROR to 500", () => {
     expect(apiErrorStatusMap[ApiErrorCode.INTERNAL_ERROR]).toBe(500);
   });
+
+  it("should map CONFLICT and INSUFFICIENT_BALANCE to 409", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.CONFLICT]).toBe(409);
+    expect(apiErrorStatusMap[ApiErrorCode.INSUFFICIENT_BALANCE]).toBe(409);
+    expect(apiErrorStatusMap[ApiErrorCode.NON_ZERO_BALANCE]).toBe(409);
+  });
+
+  it("should map OPERATION_FAILED and INVALID_PASSWORD to 400", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.OPERATION_FAILED]).toBe(400);
+    expect(apiErrorStatusMap[ApiErrorCode.INVALID_PASSWORD]).toBe(400);
+  });
+
+  it("should map BAD_GATEWAY to 502", () => {
+    expect(apiErrorStatusMap[ApiErrorCode.BAD_GATEWAY]).toBe(502);
+  });
 });
 
 describe("mapErrorCodeToStatus", () => {

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -164,6 +164,50 @@ describe("fromUnknown", () => {
     });
   });
 
+  describe("additional better-auth code mappings (body.code)", () => {
+    it("should map INVALID_TOKEN to UNAUTHORIZED", () => {
+      const error = Object.assign(new Error("Bad token"), {
+        body: { code: "INVALID_TOKEN", message: "Bad token" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.UNAUTHORIZED);
+    });
+
+    it("should map SESSION_NOT_FRESH to UNAUTHORIZED", () => {
+      const error = Object.assign(new Error("Stale session"), {
+        body: { code: "SESSION_NOT_FRESH", message: "Stale session" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.UNAUTHORIZED);
+    });
+
+    it("should map INVALID_PASSWORD to INVALID_PASSWORD", () => {
+      const error = Object.assign(new Error("Wrong password"), {
+        body: { code: "INVALID_PASSWORD", message: "Wrong password" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.INVALID_PASSWORD);
+    });
+
+    it("should map TOO_MANY_ATTEMPTS to RATE_LIMIT_EXCEEDED", () => {
+      const error = Object.assign(new Error("Too many tries"), {
+        body: { code: "TOO_MANY_ATTEMPTS", message: "Too many tries" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.RATE_LIMIT_EXCEEDED);
+    });
+
+    it("should map PROVIDER_NOT_FOUND to NOT_FOUND", () => {
+      const error = Object.assign(new Error("No provider"), {
+        body: { code: "PROVIDER_NOT_FOUND", message: "No provider" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.NOT_FOUND);
+    });
+
+    it("should map VALIDATION_ERROR in body to VALIDATION_ERROR", () => {
+      const error = Object.assign(new Error("Invalid"), {
+        body: { code: "VALIDATION_ERROR", message: "Invalid" },
+      });
+      expect(fromUnknown(error).code).toBe(ApiErrorCode.VALIDATION_ERROR);
+    });
+  });
+
   describe("non-object errors", () => {
     it("should use fallback message for string errors", () => {
       const result = fromUnknown("oops");

--- a/tests/unit/result-helpers.test.ts
+++ b/tests/unit/result-helpers.test.ts
@@ -1,0 +1,103 @@
+import { ApiErrorCode } from "@/lib/response";
+import { toApiResponse, toPaginatedApiResponse, toServiceResponse } from "@/lib/result-helpers";
+import { errAsync, okAsync } from "neverthrow";
+import { describe, expect, it } from "vitest";
+
+describe("toApiResponse", () => {
+  it("returns success status and envelope for ok ResultAsync", async () => {
+    const res = await toApiResponse(okAsync({ id: "a" }), "Created", 201);
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.message).toBe("Created");
+    expect(json.data).toEqual({ id: "a" });
+    expect(json.meta?.timestamp).toBeDefined();
+  });
+
+  it("returns HTTP status from mapErrorCodeToStatus for Err", async () => {
+    const res = await toApiResponse(
+      errAsync({ code: ApiErrorCode.EMAIL_ALREADY_EXISTS, message: "User exists" }),
+      "ignored",
+      200,
+    );
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.message).toBe("User exists");
+    expect(json.error.code).toBe(ApiErrorCode.EMAIL_ALREADY_EXISTS);
+    expect(json.error.message).toBe("User exists");
+    expect(json.meta?.timestamp).toBeDefined();
+  });
+
+  it("maps RATE_LIMIT_EXCEEDED to 429", async () => {
+    const res = await toApiResponse(errAsync({ code: ApiErrorCode.RATE_LIMIT_EXCEEDED, message: "Slow down" }), "ok");
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error.code).toBe(ApiErrorCode.RATE_LIMIT_EXCEEDED);
+  });
+
+  it("includes validation details when present on AppError", async () => {
+    const res = await toApiResponse(
+      errAsync({
+        code: ApiErrorCode.VALIDATION_ERROR,
+        message: "Validation error",
+        details: [{ code: ApiErrorCode.VALIDATION_ERROR, field: "email", message: "Invalid" }],
+      }),
+      "ok",
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.details).toHaveLength(1);
+    expect(json.error.details[0].field).toBe("email");
+  });
+});
+
+describe("toPaginatedApiResponse", () => {
+  it("puts pagination on success meta and returns 200", async () => {
+    const pagination = { page: 1, limit: 10, total: 2, totalPages: 1 };
+    const res = await toPaginatedApiResponse(okAsync({ rows: [1, 2] }), "Listed", () => ({
+      body: { rows: [1, 2] },
+      pagination,
+    }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual({ rows: [1, 2] });
+    expect(json.meta.pagination).toEqual(pagination);
+  });
+
+  it("uses same error status mapping as toApiResponse on Err", async () => {
+    const res = await toPaginatedApiResponse(
+      errAsync({ code: ApiErrorCode.NOT_FOUND, message: "Missing" }),
+      "Listed",
+      () => ({ body: {}, pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
+    );
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe(ApiErrorCode.NOT_FOUND);
+  });
+});
+
+describe("toServiceResponse", () => {
+  it("returns SuccessResponse shape for ok", async () => {
+    const out = await toServiceResponse(okAsync({ x: 1 }), "Done");
+    expect(out.success).toBe(true);
+    if (out.success) {
+      expect(out.data).toEqual({ x: 1 });
+      expect(out.message).toBe("Done");
+    }
+  });
+
+  it("returns ErrorResponse shape for err", async () => {
+    const out = await toServiceResponse(errAsync({ code: ApiErrorCode.UNAUTHORIZED, message: "Nope" }), "Done");
+    expect(out.success).toBe(false);
+    if (!out.success) {
+      expect(out.error.code).toBe(ApiErrorCode.UNAUTHORIZED);
+      expect(out.error.message).toBe("Nope");
+    }
+  });
+});


### PR DESCRIPTION
This PR keeps only the unit-test follow-up related to CZBANK-68.

It adds focused coverage for the shared error-handling pipeline:
- `toApiResponse`
- `toPaginatedApiResponse`
- `toServiceResponse`
- additional `fromUnknown` mappings
- remaining API error status mappings

No application logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for API error code to HTTP status mapping
  * Added test cases for error code conversion scenarios
  * Introduced comprehensive tests for response helper functions, including pagination and validation error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->